### PR TITLE
bug fix: stack was not being unmasked before return DFS

### DIFF
--- a/niftynet/network/dense_vnet.py
+++ b/niftynet/network/dense_vnet.py
@@ -415,6 +415,23 @@ class DenseFeatureStackBlock(TrainableLayer):
 
             stack.append(conv)
 
+        # unmask the stack
+        channels = tf.unstack(stack, axis=-1)
+        # exclude the input channels
+        channels = channels[input_channels:]
+        input_mask = input_mask[input_channels:]
+        # create a channel with zeros to be placed where channels were not calculated
+        channels.insert(0, tf.zeros_like(channels[0]))
+        # re stack
+        channels = tf.stack(channels, axis=-1)
+
+        # indices to keep
+        int_mask = tf.cast(input_mask, tf.int32)
+        indices = tf.cumsum(int_mask) * int_mask
+        # rearrange stack with zeros where channels were not calculated
+        stack = tf.gather(channels, indices, axis=-1)
+        stack = tf.unstack(stack, axis=-1)
+
         return stack
 
 


### PR DESCRIPTION
In class DenseFeatureStackBlock (DFS) the stack was not being unmasked before being returned.
This causes the subsequent layers to not have the full output of the DFS and weigh different features with the same weights.
In addition, the input of the DFS was also being returned in the stack. 
In short, the number and location of the DFS's output channels was incorrect.

This bug fix:
1. Removes the input of the DFS from the stack
2. Unmasks the stack by filling in zeros where the channels which were not compute due to dropout were.

I talked with the author of the paper and he confirmed this is a reimplementation bug.
I have tested this approach with a toy program but haven't trained a network with it.

Suggestion: In the future, you can keep the stack as tensor instead of as a list, this avoids so much stacking and unstacking in the code. They are replaced by concatenation and slicing. I didn't change this so that my changes were minimal.

Hope this helps, 

Miguel
