### PR TITLE
Moved CI tests from Adelie to Little

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,6 +17,7 @@ pylintjob:
     - 206-improve-the-handling-of-release-notes
     - 221-add-changelog-entry-for-version-0.2.2
     - 223-put-bug-fixes-under-fixed-header-in-changelog
+    - 173-move-ci-tests-to-gift-little
   script:
     - pylint --rcfile=tests/pylintrc niftynet/engine
     - pylint --rcfile=tests/pylintrc niftynet/io/image_*py
@@ -33,6 +34,7 @@ testjob:
     - dev
     - tags
     - cherrypick-from-dev-to-v0.2.1-for-v0.2.2-release
+    - 173-move-ci-tests-to-gift-little
   script:
     # !!kill coverage in case of hanging processes
     - if pgrep coverage; then pkill -f coverage; fi
@@ -223,6 +225,7 @@ quicktest:
     - 223-put-bug-fixes-under-fixed-header-in-changelog
     - 195-add-evaluation-action-3
     - 192-model_zoo_tests
+    - 173-move-ci-tests-to-gift-little
   script:
     # print system info
     - which nvidia-smi
@@ -265,6 +268,7 @@ pip-installer:
     - dev
     - tags
     - 117-support-for-user-defined-networks-using-pip-installed-niftynet
+    - 173-move-ci-tests-to-gift-little
   script:
     # get the shortened version of last commit's hash
     - LAST_COMMIT=$(git rev-parse --short HEAD)
@@ -462,6 +466,7 @@ pip-camera-ready:
   stage: pip_publish
   only:
     - tags
+    - 173-move-ci-tests-to-gift-little
   script:
     # Copy wheel created in previous stage to a specific location on GIFT-Adelie
     - export niftynet_dir=$(pwd)
@@ -499,6 +504,7 @@ release-notes:
   stage: release_notes
   only:
     - tags
+    - 173-move-ci-tests-to-gift-little
   script:
     - echo $CI_COMMIT_REF_NAME
     - echo $CI_COMMIT_TAG

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,6 @@ pylintjob:
     - 206-improve-the-handling-of-release-notes
     - 221-add-changelog-entry-for-version-0.2.2
     - 223-put-bug-fixes-under-fixed-header-in-changelog
-    - 173-move-ci-tests-to-gift-little
   script:
     - pylint --rcfile=tests/pylintrc niftynet/engine
     - pylint --rcfile=tests/pylintrc niftynet/io/image_*py
@@ -34,7 +33,6 @@ testjob:
     - dev
     - tags
     - cherrypick-from-dev-to-v0.2.1-for-v0.2.2-release
-    - 173-move-ci-tests-to-gift-little
   script:
     # !!kill coverage in case of hanging processes
     - if pgrep coverage; then pkill -f coverage; fi
@@ -225,7 +223,6 @@ quicktest:
     - 223-put-bug-fixes-under-fixed-header-in-changelog
     - 195-add-evaluation-action-3
     - 192-model_zoo_tests
-    - 173-move-ci-tests-to-gift-little
   script:
     # print system info
     - which nvidia-smi
@@ -268,7 +265,6 @@ pip-installer:
     - dev
     - tags
     - 117-support-for-user-defined-networks-using-pip-installed-niftynet
-    - 173-move-ci-tests-to-gift-little
   script:
     # get the shortened version of last commit's hash
     - LAST_COMMIT=$(git rev-parse --short HEAD)
@@ -466,7 +462,6 @@ pip-camera-ready:
   stage: pip_publish
   only:
     - tags
-    - 173-move-ci-tests-to-gift-little
   script:
     # Copy wheel created in previous stage to a specific location on GIFT-Adelie
     - export niftynet_dir=$(pwd)
@@ -504,7 +499,6 @@ release-notes:
   stage: release_notes
   only:
     - tags
-    - 173-move-ci-tests-to-gift-little
   script:
     - echo $CI_COMMIT_REF_NAME
     - echo $CI_COMMIT_TAG

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -200,7 +200,7 @@ testjob:
     - coverage report -m
     - echo 'finished test'
   tags:
-    - gift-linux
+    - gift-little
 
 quicktest:
   stage: dev_test
@@ -456,7 +456,7 @@ pip-installer:
     - deactivate
     - cd $niftynet_dir
   tags:
-    - gift-adelie
+    - gift-little
 
 pip-camera-ready:
   stage: pip_publish
@@ -493,7 +493,7 @@ pip-camera-ready:
     - echo "Camera-ready pip installer bundle (wheel) created:"
     - echo "$(ls $camera_ready_dir/*.whl)"
   tags:
-    - gift-adelie
+    - gift-little
 
 release-notes:
   stage: release_notes
@@ -514,4 +514,4 @@ release-notes:
           echo "... DONE"
         fi
   tags:
-    - gift-adelie
+    - gift-little

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,6 +23,8 @@ pylintjob:
     - pylint --rcfile=tests/pylintrc niftynet/utilities/user_parameters_*py
     - pylint --rcfile=tests/pylintrc niftynet/utilities/download.py
     - pylint --rcfile=tests/pylintrc niftynet/utilities/niftynet_global_config.py
+  tags:
+    - gift-little
 
 testjob:
   stage: dev_test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -253,7 +253,7 @@ quicktest:
 
     - echo 'finished quick tests'
   tags:
-    - gift-linux
+    - gift-little
 
 
 pip-installer:


### PR DESCRIPTION
## Status
**READY**

## Description
A GitLab CI runner has been set up on GIFT-Little. These changes effectively switch the CI tests from GIFT-Adelie to GIFT-Little.

## Impacted Areas in Application
The virtually same environment as Adelie has been set up on Little. As such, this PR should not have any impact. However as discussed in the #173 thread, CI builds sometimes fail with unspecific errors.