### PR TITLE
Add Tversky loss for segmentation

### DIFF
--- a/niftynet/engine/application_factory.py
+++ b/niftynet/engine/application_factory.py
@@ -86,6 +86,8 @@ SUPPORTED_LOSS_SEGMENTATION = {
         'niftynet.layer.loss_segmentation.dice_dense',
     "Dice_Dense_NS":
         'niftynet.layer.loss_segmentation.dice_dense_nosquare',
+    "Tversky":
+        'niftynet.layer.loss_segmentation.tversky',
     "GDSC":
         'niftynet.layer.loss_segmentation.generalised_dice_loss',
     "WGDL":

--- a/niftynet/layer/README.md
+++ b/niftynet/layer/README.md
@@ -6,13 +6,13 @@ Summary of layers that can be used to build networks and their characteristics
 File: activation.py
 Possible activation layers to be specified as the acti_func field of ConvolutionLayer or DeconvolutionLayer among the following values:
 
-Field | Equation 
+Field | Equation
 ------|----------
 relu  |[relu_eq](./figures/relu_eq.pdf)
 relu6 |[relu6_eq](./figures/relu6_eq.pdf)
 elu | [elu_eq](./figures/elu_eq.pdf)
 softplus |[softplus_eq](./figures/softplus_eq.pdf)
-softsign |[softsign_eq](./figures/softsign_eq.pdf) 
+softsign |[softsign_eq](./figures/softsign_eq.pdf)
 sigmoid |[sigmoid_eq](./figures/sigmoid_eq.pdf)
 tanh |[tanh_eq](./figures/tanh_eq.pdf)
 prelu |[prelu_eq](./figures/prelu_eq.pdf)
@@ -111,7 +111,7 @@ The normalisation follows [the method](http://ieeexplore.ieee.org/abstract/docum
 [^1]: Nyúl, L. G., Udupa, J. K., & Zhang, X. (2000). New variants of a method of MRI scale standardization. IEEE transactions on medical imaging, 19(2), 143-150.
 
 ## Loss functions
-Loss functions are application-specific. 
+Loss functions are application-specific.
 
 File: loss_segmentation.py
 Class: LossFunction
@@ -122,44 +122,45 @@ Fields:
 * loss_func_params: Additional parameters to be used for the specified loss
 * name
 
-Following is a brief description of the loss functions for segmentation: 
+Following is a brief description of the loss functions for segmentation:
 
 Loss function| Notes | Citation | Additional Arguments
-------|----------|------ | -----| 
-Cross-entropy |  | 
+------|----------|------ | -----|
+Cross-entropy |  |
 Dice Loss |  | "V-net: Fully convolutional neural networks for volumetric medical image segmentation", Milletari, et al, 3DV 2016.
 Dice Loss (no square) | Similar to Dice Loss, but probabilities are not squared in the denominator. |
-Generalised Dice Loss | | "Generalised Dice overlap as a deep learning loss function for highly unbalanced segmentations", Sudre, C. et. al.  DLMIA 2017.| type_weight: default 'Square'. Indicates how the volume of each label is weighted. Square - Multiplication by the inverse of square of the volume / Simple - Multiplication by 1/V / Uniform - No weighting 
+Generalised Dice Loss | | "Generalised Dice overlap as a deep learning loss function for highly unbalanced segmentations", Sudre, C. et. al.  DLMIA 2017.| type_weight: default 'Square'. Indicates how the volume of each label is weighted. Square - Multiplication by the inverse of square of the volume / Simple - Multiplication by 1/V / Uniform - No weighting
 Generalised Wasserstein Dice Loss | | "Generalised Wasserstein Dice Score for Imbalanced Multi-class Segmentation using Holistic Convolutional Networks", Fidon, L. et. al. MICCAI 2017 (BrainLes).
 Sensitivity-Specificity Loss  | | "Deep Convolutional Encoder Networks for Multiple Sclerosis Lesion Segmentation", Brosch et al, MICCAI 2015. | r: default 0.05. The 'sensitivity ratio' (authors suggest values from 0.01-0.10 will have similar effects)
+Tversky index | | "Tversky loss function for image segmentation using 3D fully convolutional deep networks", Sadegh S. et al., 2017 | `alpha` and `beta` are parameters that control the trade-off between false positives and false negatives
 
 
-File: loss_regression.py 
+File: loss_regression.py
 Class: LossFunction
 * n_class: Number of classes/labels
 * loss_type: ['L1Loss'/ 'L2Loss'/ 'Huber'/ 'RMSE'] Name of the loss to be applied
 * loss_func_params: Additional parameters to be used for the specified loss
 * name
 
-Following is a brief description of the regression loss functions: 
+Following is a brief description of the regression loss functions:
 
 Loss function| Notes | Citation | Additional Arguments
-----------|----|---- | ---| 
+----------|----|---- | ---|
 L<sub>1</sub> Loss | |
-L<sub>2</sub> Loss | | 
+L<sub>2</sub> Loss | |
 Huber Loss |     The Huber loss is a smooth piecewise loss function that is quadratic for &#x7c;x&#x7c; <= delta, and linear for &#x7c;x&#x7c;> delta. See https://en.wikipedia.org/wiki/Huber_loss| | delta: default 1.0
-Root Mean Square Error | | | 
+Root Mean Square Error | | |
 
 ## Random flip
-This layer introduces flipping along user-specified axes. 
-This can be useful as a data-augmentation step in training. 
+This layer introduces flipping along user-specified axes.
+This can be useful as a data-augmentation step in training.
 
-File: rand_flip.py 
+File: rand_flip.py
 Class: RandomFlipLayer
-Fields: 
+Fields:
 
-* flip_axes: which axes to flip on. 
-* flip_probability: default 0.5. The probability of flipping along any of the specified axes. 
+* flip_axes: which axes to flip on.
+* flip_probability: default 0.5. The probability of flipping along any of the specified axes.
 
 ## Random rotation
 File: rand_rotation.py

--- a/niftynet/layer/loss_segmentation.py
+++ b/niftynet/layer/loss_segmentation.py
@@ -465,6 +465,51 @@ def dice_nosquare(prediction, ground_truth, weight_map=None):
     return 1.0 - tf.reduce_mean(dice_score)
 
 
+def tversky(prediction, ground_truth, weight_map=None, alpha=0.5, beta=0.5):
+    """
+    Function to calculate the Tversky loss for imbalanced data
+
+        Sadegh et al. (2017)
+
+        Tversky loss function for image segmentation
+        using 3D fully convolutional deep networks
+
+    :param prediction: the logits
+    :param ground_truth: the segmentation ground_truth
+    :param alpha: weight of false positives
+    :param beta: weight of false negatives
+    :param weight_map:
+    :return: the loss
+    """
+    prediction = tf.to_float(prediction)
+    if len(ground_truth.shape) == len(prediction.shape):
+        ground_truth = ground_truth[..., -1]
+    one_hot = labels_to_one_hot(ground_truth, tf.shape(prediction)[-1])
+
+    p0 = prediction
+    p1 = 1 - prediction
+    g0 = one_hot
+    g1 = 1 - one_hot
+
+    if weight_map is not None:
+        num_classes = prediction.shape[1].value
+        weight_map_flattened = tf.reshape(weight_map, [-1])
+        weight_map_expanded = tf.expand_dims(weight_map_flattened, 1)
+        w = tf.tile(weight_map_expanded, [1, num_classes])
+    else:
+        w = 1
+
+    tp = tf.sparse_reduce_sum(w * p0 * g0, reduction_axes=[0])
+    fp = alpha * tf.sparse_reduce_sum(w * p0 * g1, reduction_axes=[0])
+    fn = beta * tf.sparse_reduce_sum(w * p1 * g0, reduction_axes=[0])
+
+    EPSILON = 0.00001
+    numerator = tp
+    denominator = tp + fp + fn + EPSILON
+    score = numerator / denominator
+    return 1.0 - tf.reduce_mean(score)
+
+
 def dice_dense(prediction, ground_truth, weight_map=None):
     """
     Computing mean-class Dice similarity.

--- a/tests/loss_segmentation_test.py
+++ b/tests/loss_segmentation_test.py
@@ -255,6 +255,48 @@ class DiceTestNoSquare(tf.test.TestCase):
             self.assertAlmostEqual(one_minus_dice_score.eval(), 1.0)
 
 
+class TverskyTest(tf.test.TestCase):
+    def test_tversky_index(self):
+        with self.test_session():
+            predicted = tf.constant(
+                [[0, 10], [10, 0], [10, 0], [10, 0]],
+                dtype=tf.float32, name='predicted')
+            labels = tf.constant([1, 0, 0, 0], dtype=tf.int64, name='labels')
+            predicted, labels = [tf.expand_dims(x, axis=0) for x in (predicted, labels)]
+
+            test_loss_func = LossFunction(2, loss_type='Tversky')
+            one_minus_dice_score = test_loss_func(predicted, labels)
+            self.assertAllClose(one_minus_dice_score.eval(), 0.0, atol=1e-4)
+
+    def test_tversky_index_weights(self):
+        with self.test_session():
+            weights = tf.constant([[1, 1, 0, 0]], dtype=tf.float32,
+                                  name='weights')
+            predicted = tf.constant(
+                [[0, 10], [10, 0], [10, 0], [10, 0]],
+                dtype=tf.float32, name='predicted')
+            labels = tf.constant([[1, 0, 0, 0]], dtype=tf.int64, name='labels')
+            predicted, labels = [tf.expand_dims(x, axis=0) for x in (predicted, labels)]
+
+            test_loss_func = LossFunction(2,
+                                          loss_type='Tversky')
+            one_minus_dice_score = test_loss_func(predicted, labels,
+                                                  weight_map=weights)
+            self.assertAllClose(one_minus_dice_score.eval(), 0.0, atol=1e-4)
+
+    def test_wrong_prediction(self):
+        with self.test_session():
+            predicted = tf.constant(
+                [[0, 100]],
+                dtype=tf.float32, name='predicted')
+            labels = tf.constant([0], dtype=tf.int64, name='labels')
+            predicted, labels = [tf.expand_dims(x, axis=0) for x in (predicted, labels)]
+
+            test_loss_func = LossFunction(2, loss_type='Tversky')
+            one_minus_dice_score = test_loss_func(predicted, labels)
+            self.assertAlmostEqual(one_minus_dice_score.eval(), 1.0)
+
+
 class DiceDenseTest(tf.test.TestCase):
     def test_dice_dense_score(self):
         with self.test_session():

--- a/tests/loss_segmentation_test.py
+++ b/tests/loss_segmentation_test.py
@@ -262,11 +262,12 @@ class TverskyTest(tf.test.TestCase):
                 [[0, 10], [10, 0], [10, 0], [10, 0]],
                 dtype=tf.float32, name='predicted')
             labels = tf.constant([1, 0, 0, 0], dtype=tf.int64, name='labels')
-            predicted, labels = [tf.expand_dims(x, axis=0) for x in (predicted, labels)]
+            predicted, labels = [tf.expand_dims(x, axis=0)
+                                 for x in (predicted, labels)]
 
             test_loss_func = LossFunction(2, loss_type='Tversky')
-            one_minus_dice_score = test_loss_func(predicted, labels)
-            self.assertAllClose(one_minus_dice_score.eval(), 0.0, atol=1e-4)
+            one_minus_tversky_index = test_loss_func(predicted, labels)
+            self.assertAllClose(one_minus_tversky_index.eval(), 0.0, atol=1e-4)
 
     def test_tversky_index_weights(self):
         with self.test_session():
@@ -276,13 +277,14 @@ class TverskyTest(tf.test.TestCase):
                 [[0, 10], [10, 0], [10, 0], [10, 0]],
                 dtype=tf.float32, name='predicted')
             labels = tf.constant([[1, 0, 1, 0]], dtype=tf.int64, name='labels')
-            predicted, labels = [tf.expand_dims(x, axis=0) for x in (predicted, labels)]
+            predicted, labels = [tf.expand_dims(x, axis=0)
+                                 for x in (predicted, labels)]
 
             test_loss_func = LossFunction(2,
                                           loss_type='Tversky')
-            one_minus_dice_score = test_loss_func(predicted, labels,
-                                                  weight_map=weights)
-            self.assertAllClose(one_minus_dice_score.eval(), 0.0, atol=1e-4)
+            one_minus_tversky_index = test_loss_func(predicted, labels,
+                                                     weight_map=weights)
+            self.assertAllClose(one_minus_tversky_index.eval(), 0.0, atol=1e-4)
 
     def test_wrong_prediction(self):
         with self.test_session():
@@ -290,11 +292,12 @@ class TverskyTest(tf.test.TestCase):
                 [[0, 100]],
                 dtype=tf.float32, name='predicted')
             labels = tf.constant([0], dtype=tf.int64, name='labels')
-            predicted, labels = [tf.expand_dims(x, axis=0) for x in (predicted, labels)]
+            predicted, labels = [tf.expand_dims(x, axis=0)
+                                 for x in (predicted, labels)]
 
             test_loss_func = LossFunction(2, loss_type='Tversky')
-            one_minus_dice_score = test_loss_func(predicted, labels)
-            self.assertAlmostEqual(one_minus_dice_score.eval(), 1.0)
+            one_minus_tversky_index = test_loss_func(predicted, labels)
+            self.assertAlmostEqual(one_minus_tversky_index.eval(), 1.0)
 
 
 class DiceDenseTest(tf.test.TestCase):

--- a/tests/loss_segmentation_test.py
+++ b/tests/loss_segmentation_test.py
@@ -275,7 +275,7 @@ class TverskyTest(tf.test.TestCase):
             predicted = tf.constant(
                 [[0, 10], [10, 0], [10, 0], [10, 0]],
                 dtype=tf.float32, name='predicted')
-            labels = tf.constant([[1, 0, 0, 0]], dtype=tf.int64, name='labels')
+            labels = tf.constant([[1, 0, 1, 0]], dtype=tf.int64, name='labels')
             predicted, labels = [tf.expand_dims(x, axis=0) for x in (predicted, labels)]
 
             test_loss_func = LossFunction(2,


### PR DESCRIPTION
## Status
**READY**

## Description
Tversky loss is useful for segmenting imbalanced data. It uses two
hyperparameters `alpha` and `beta` as a trade-off between precision and
recall.

If `alpha` + `beta` = 1, it's an F-score.
If `alpha` = `beta` = 0.5, it's an F1-score (Dice).

See [Sadegh et al. (2017): Tversky loss function for image segmentation using 3D fully convolutional deep networks](https://arxiv.org/abs/1706.05721).

This resolves #200 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


## Todos
- [x] Tests
- [x] Documentation


## Impacted Areas in Application
List general components of the application that this PR will affect:
* Segmentation training
