### PR TITLE
fixes pixdim and axcodes

### DIFF
--- a/tests/image_type_test.py
+++ b/tests/image_type_test.py
@@ -87,8 +87,8 @@ class ImageTypeTest(tf.test.TestCase):
             loader=None)
         self.assertIsInstance(image, SpatialImage3D)
         output = image.get_data()
-        self.assertAllClose(np.array([23, 317, 31, 1, 1]), output.shape)
-        self.assertAllClose(np.array([23, 317, 31, 1, 1]), image.shape)
+        self.assertAllClose(np.array([36, 208, 31, 1, 1]), output.shape)
+        self.assertAllClose(np.array([36, 208, 31, 1, 1]), image.shape)
 
     def test_multiple_3d_as_4d(self):
         image = ImageFactory.create_instance(
@@ -168,8 +168,8 @@ class ImageTypeTest(tf.test.TestCase):
             loader=(None, None))
         self.assertIsInstance(image, SpatialImage4D)
         output = image.get_data()
-        self.assertAllClose(np.array([33, 190, 42, 1, 2]), output.shape)
-        self.assertAllClose(np.array([33, 190, 42, 1, 2]), image.shape)
+        self.assertAllClose(np.array([50, 125, 42, 1, 2]), output.shape)
+        self.assertAllClose(np.array([50, 125, 42, 1, 2]), image.shape)
 
     def test_5d(self):
         image = ImageFactory.create_instance(
@@ -221,8 +221,8 @@ class ImageTypeTest(tf.test.TestCase):
             loader=(None,))
         self.assertIsInstance(image, SpatialImage5D)
         output = image.get_data()
-        self.assertAllClose(np.array([29, 31, 29, 1, 1]), output.shape)
-        self.assertAllClose(np.array([29, 31, 29, 1, 1]), image.shape)
+        self.assertAllClose(np.array([29, 33, 28, 1, 1]), output.shape)
+        self.assertAllClose(np.array([29, 33, 28, 1, 1]), image.shape)
 
 
 if __name__ == "__main__":

--- a/tests/windows_aggregator_grid_v2_test.py
+++ b/tests/windows_aggregator_grid_v2_test.py
@@ -23,7 +23,7 @@ MULTI_MOD_DATA = {
         filename_not_contains=('Parcellation',),
         interp_order=3,
         pixdim=(2.4, 5.0, 2.0),
-        axcodes='LAS',
+        axcodes='LSA',
         spatial_window_size=(23, 32, 15),
         loader=None
     ),
@@ -34,7 +34,7 @@ MULTI_MOD_DATA = {
         filename_not_contains=('Parcellation',),
         interp_order=3,
         pixdim=(2.4, 5.0, 2.0),
-        axcodes='LAS',
+        axcodes='LSA',
         spatial_window_size=(23, 32, 15),
         loader=None
     )
@@ -79,7 +79,7 @@ SINGLE_25D_DATA = {
         filename_not_contains=('Parcellation',),
         interp_order=3,
         pixdim=(3.0, 5.0, 5.0),
-        axcodes='LAS',
+        axcodes='ASL',
         spatial_window_size=(40, 30, 1),
         loader=None
     ),
@@ -213,7 +213,7 @@ class GridSamplesAggregatorTest(tf.test.TestCase):
                                    'aggregated',
                                    output_filename)
         self.assertAllClose(
-            nib.load(output_file).shape, [256, 168, 256, 1, 1],
+            nib.load(output_file).shape, [168, 256, 256, 1, 1],
             rtol=1e-03, atol=1e-03)
         sampler.close_all()
 


### PR DESCRIPTION

## Status
**READY**

## Description
This commit concerns the order of running resampling and axes transposing.
When new pixdim and axcode are specified, the new pixdim will be interpreted as the pixdim of the
image after reorientation (Relevant issue https://github.com/NifTK/NiftyNet/issues/153).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] All new and existing tests passed.

## Impacted Areas in Application
List general components of the application that this PR will affect:
* image pixdim, image axcode configuration
