### PR TITLE
Add Gaussian smoothing before undersampling

### DIFF
--- a/doc/source/config_spec.md
+++ b/doc/source/config_spec.md
@@ -567,8 +567,15 @@ Value should be in `[0, 1]`.
  ---- | ---- | ------- | -------
 [rotation_angle](#rotation-angle) | `float array` | `rotation_angle=-10.0,10.0` | `''`
 [scaling_percentage](#scaling-percentage) | `float array` | `scaling_percentage=-20.0,20.0` | `''`
-[antialiasing](#antialiasing) | `boolean` | `antialiasing=True` | `True`
+[antialiasing](#scaling-percentage) | `boolean` | `antialiasing=True` | `True`
 [random_flipping_axes](#random-flipping-axes) | `integer array` | `random_flipping_axes=1,2` | `-1`
+[do_elastic_deformation](#do-elastic-deformation) | `boolean` | `do_elastic_deformation=True` | `False`
+[num_ctrl_points](#do-elastic-deformation) | `integer` | `num_ctrl_points=1` | `4`
+[deformation_sigma](#do-elastic-deformation) | `float` | `deformation_sigma=1` | `15`
+[proportion_to_deform](#do-elastic-deformation) | `float` | `proportion_to_deform=0.7` | `0.5`
+[bias_field_range](#bias-field-range) | `float array` | `bias_field_range=-10.0,10.0` | `''`
+[bf_order](#bias-field-range) | `integer` | `bf_order=1` | `3`
+
 
 ###### `rotation_angle`
 Float array, indicates a random rotation operation should be applied to the
@@ -581,14 +588,28 @@ The option accepts percentages relative to 100 (the original input size).
 E.g, `(-50, 50)` indicates transforming
 image (size `d`) to image with its size in between `0.5*d` and `1.5d`.
 
-###### `antialiasing`
-Boolean value indicates if antialiasing should be performed
+When random scaling is enabled, it is possible to further specify:
+- `antialiasing` indicating if antialiasing should be performed
 when randomly downsampling the input images.
 
 ###### `random_flipping_axes`
 The axes which can be flipped to augment the data.
 Supply as comma-separated values within single quotes, e.g. '0,1'.
 Note that these are 0-indexed, so choose some combination of 0, 1.
+
+###### `do_elastic_deformation`
+Boolean value indicates data augmentation using elastic deformations
+
+When `do_elastic_deformation=True`, it is possible to further specify:
+- `num_ctrl_points` -- number of control points for the elastic deformation,
+- `deformation_sigma` -- the standard deviation for the elastic deformation,
+- `proportion_to_deform` -- what fraction of samples to deform elastically.
+
+###### `bias_field_range`
+Float array, indicates data augmentation with randomised bias field
+
+When `bias_field_range` is not None, it is possible to further specify:
+- `bf_order` -- maximal polynomial order to use for the bias field augmentation.
 
 
 ### INFERENCE

--- a/doc/source/config_spec.md
+++ b/doc/source/config_spec.md
@@ -567,6 +567,7 @@ Value should be in `[0, 1]`.
  ---- | ---- | ------- | -------
 [rotation_angle](#rotation-angle) | `float array` | `rotation_angle=-10.0,10.0` | `''`
 [scaling_percentage](#scaling-percentage) | `float array` | `scaling_percentage=-20.0,20.0` | `''`
+[antialiasing](#antialiasing) | `boolean` | `antialiasing=True` | `True`
 [random_flipping_axes](#random-flipping-axes) | `integer array` | `random_flipping_axes=1,2` | `-1`
 
 ###### `rotation_angle`
@@ -580,6 +581,9 @@ The option accepts percentages relative to 100 (the original input size).
 E.g, `(-50, 50)` indicates transforming
 image (size `d`) to image with its size in between `0.5*d` and `1.5d`.
 
+###### `antialiasing`
+Boolean value indicates if antialiasing should be performed
+when randomly downsampling the input images.
 
 ###### `random_flipping_axes`
 The axes which can be flipped to augment the data.

--- a/niftynet/application/classification_application.py
+++ b/niftynet/application/classification_application.py
@@ -135,7 +135,8 @@ class ClassificationApplication(BaseApplication):
             if train_param.scaling_percentage:
                 augmentation_layers.append(RandomSpatialScalingLayer(
                     min_percentage=train_param.scaling_percentage[0],
-                    max_percentage=train_param.scaling_percentage[1]))
+                    max_percentage=train_param.scaling_percentage[1],
+                    antialiasing=train_param.antialiasing))
             if train_param.rotation_angle or \
                     self.action_param.rotation_angle_x or \
                     self.action_param.rotation_angle_y or \

--- a/niftynet/application/gan_application.py
+++ b/niftynet/application/gan_application.py
@@ -103,7 +103,8 @@ class GANApplication(BaseApplication):
             if self.action_param.scaling_percentage:
                 augmentation_layers.append(RandomSpatialScalingLayer(
                     min_percentage=self.action_param.scaling_percentage[0],
-                    max_percentage=self.action_param.scaling_percentage[1]))
+                    max_percentage=self.action_param.scaling_percentage[1],
+                    antialiasing=self.action_param.antialiasing))
             if self.action_param.rotation_angle:
                 augmentation_layers.append(RandomRotationLayer())
                 augmentation_layers[-1].init_uniform_angle(

--- a/niftynet/application/regression_application.py
+++ b/niftynet/application/regression_application.py
@@ -124,7 +124,8 @@ class RegressionApplication(BaseApplication):
             if train_param.scaling_percentage:
                 augmentation_layers.append(RandomSpatialScalingLayer(
                     min_percentage=train_param.scaling_percentage[0],
-                    max_percentage=train_param.scaling_percentage[1]))
+                    max_percentage=train_param.scaling_percentage[1],
+                    antialiasing=train_param.antialiasing))
             if train_param.rotation_angle:
                 rotation_layer = RandomRotationLayer()
                 if train_param.rotation_angle:

--- a/niftynet/application/segmentation_application.py
+++ b/niftynet/application/segmentation_application.py
@@ -150,7 +150,8 @@ class SegmentationApplication(BaseApplication):
             if train_param.scaling_percentage:
                 augmentation_layers.append(RandomSpatialScalingLayer(
                     min_percentage=train_param.scaling_percentage[0],
-                    max_percentage=train_param.scaling_percentage[1]))
+                    max_percentage=train_param.scaling_percentage[1],
+                    antialiasing=train_param.antialiasing))
             if train_param.rotation_angle or \
                     train_param.rotation_angle_x or \
                     train_param.rotation_angle_y or \

--- a/niftynet/contrib/preprocessors/preprocessing.py
+++ b/niftynet/contrib/preprocessors/preprocessing.py
@@ -57,7 +57,8 @@ class Preprocessing:
         if self.action_param.scaling_percentage:
             augmentation_layers.append(RandomSpatialScalingLayer(
                 min_percentage=self.action_param.scaling_percentage[0],
-                max_percentage=self.action_param.scaling_percentage[1]))
+                max_percentage=self.action_param.scaling_percentage[1],
+                antialiasing=self.action_param.antialiasing))
         if self.action_param.rotation_angle or \
                 self.action_param.rotation_angle_x or \
                 self.action_param.rotation_angle_y or \

--- a/niftynet/layer/rand_spatial_scaling.py
+++ b/niftynet/layer/rand_spatial_scaling.py
@@ -54,7 +54,6 @@ class RandomSpatialScalingLayer(RandomisedLayer):
         while len(full_zoom) < image.ndim:
             full_zoom = np.hstack((full_zoom, [1.0]))
         smooth = all(full_zoom[:3] < 1)  # perform smoothing if undersampling
-        smooth = False
         if smooth:
             sigma = self._get_sigma(full_zoom[:3])
         if image.ndim == 4:

--- a/niftynet/layer/rand_spatial_scaling.py
+++ b/niftynet/layer/rand_spatial_scaling.py
@@ -46,7 +46,7 @@ class RandomSpatialScalingLayer(RandomisedLayer):
         sigma = np.sqrt(variance)
         return sigma
 
-    def _apply_transformation(self, image, interp_order=3):
+    def _apply_transformation(self, image, interp_order=3, antialiasing=True):
         if interp_order < 0:
             return image
         assert self._rand_zoom is not None
@@ -59,7 +59,7 @@ class RandomSpatialScalingLayer(RandomisedLayer):
         if image.ndim == 4:
             output = []
             for mod in range(image.shape[-1]):
-                if smooth:
+                if smooth and antialiasing:
                     original_resolution = ndi.gaussian_filter(
                         image[..., mod], sigma)
                 else:
@@ -69,7 +69,7 @@ class RandomSpatialScalingLayer(RandomisedLayer):
                 output.append(scaled[..., np.newaxis])
             return np.concatenate(output, axis=-1)
         elif image.ndim == 3:
-            if smooth:
+            if smooth and antialiasing:
                 original_resolution = ndi.gaussian_filter(
                     image, sigma)
             else:

--- a/niftynet/layer/rand_spatial_scaling.py
+++ b/niftynet/layer/rand_spatial_scaling.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import, print_function
 import warnings
 
 import numpy as np
-import scipy.ndimage
+import scipy.ndimage as ndi
 
 from niftynet.layer.base_layer import RandomisedLayer
 
@@ -22,7 +22,7 @@ class RandomSpatialScalingLayer(RandomisedLayer):
                  max_percentage=10.0,
                  name='random_spatial_scaling'):
         super(RandomSpatialScalingLayer, self).__init__(name=name)
-        assert min_percentage < max_percentage
+        assert min_percentage <= max_percentage
         self._min_percentage = max(min_percentage, -99.9)
         self._max_percentage = max_percentage
         self._rand_zoom = None
@@ -34,6 +34,18 @@ class RandomSpatialScalingLayer(RandomisedLayer):
                                       size=(spatial_rank,))
         self._rand_zoom = (rand_zoom + 100.0) / 100.0
 
+    def _get_sigma(self, zoom):
+        """
+        Compute optimal standard deviation for Gaussian kernel.
+
+            Cardoso et al., "Scale factor point spread function matching:
+            beyond aliasing in image resampling", MICCAI 2015
+        """
+        k = 1 / zoom
+        variance = (k ** 2 - 1 ** 2) * (2 * np.sqrt(2 * np.log(2))) ** (-2)
+        sigma = np.sqrt(variance)
+        return sigma
+
     def _apply_transformation(self, image, interp_order=3):
         if interp_order < 0:
             return image
@@ -41,20 +53,33 @@ class RandomSpatialScalingLayer(RandomisedLayer):
         full_zoom = np.array(self._rand_zoom)
         while len(full_zoom) < image.ndim:
             full_zoom = np.hstack((full_zoom, [1.0]))
+        smooth = all(full_zoom[:3] < 1)  # perform smoothing if undersampling
+        smooth = False
+        if smooth:
+            sigma = self._get_sigma(full_zoom[:3])
         if image.ndim == 4:
             output = []
             for mod in range(image.shape[-1]):
-                scaled = scipy.ndimage.zoom(image[..., mod],
-                                            full_zoom[:3],
-                                            order=interp_order)
+                if smooth:
+                    original_resolution = ndi.gaussian_filter(
+                        image[..., mod], sigma)
+                else:
+                    original_resolution = image[..., mod]
+                scaled = ndi.zoom(
+                    original_resolution, full_zoom[:3], order=interp_order)
                 output.append(scaled[..., np.newaxis])
             return np.concatenate(output, axis=-1)
-        if image.ndim == 3:
-            scaled = scipy.ndimage.zoom(image,
-                                        full_zoom[:3],
-                                        order=interp_order)
+        elif image.ndim == 3:
+            if smooth:
+                original_resolution = ndi.gaussian_filter(
+                    image, sigma)
+            else:
+                original_resolution = image
+            scaled = ndi.zoom(
+                original_resolution, full_zoom[:3], order=interp_order)
             return scaled[..., np.newaxis]
-        raise NotImplementedError('not implemented random scaling')
+        else:
+            raise NotImplementedError('not implemented random scaling')
 
     def layer_op(self, inputs, interp_orders, *args, **kwargs):
         if inputs is None:

--- a/niftynet/utilities/user_parameters_default.py
+++ b/niftynet/utilities/user_parameters_default.py
@@ -485,6 +485,13 @@ def add_training_args(parser):
         default=())
 
     parser.add_argument(
+        "--antialiasing",
+        help="Indicates if antialiasing must be performed "
+             "when randomly scaling the input images",
+        type=str2boolean,
+        default=True)
+
+    parser.add_argument(
         "--bias_field_range",
         help="[Training only] The range of bias field coeffs in [min_coeff, "
              "max_coeff]",

--- a/niftynet/utilities/user_parameters_default.py
+++ b/niftynet/utilities/user_parameters_default.py
@@ -520,16 +520,19 @@ def add_training_args(parser):
         help="Enables elastic deformation",
         type=str2boolean,
         default=False)
+
     parser.add_argument(
         "--num_ctrl_points",
         help="Number of control points for the elastic deformation",
         type=int,
         default=4)
+
     parser.add_argument(
         "--deformation_sigma",
         help="The standard deviation for elastic deformation.",
         type=float,
         default=15)
+
     parser.add_argument(
         "--proportion_to_deform",
         help="What fraction of samples to deform elastically.",


### PR DESCRIPTION
## Status
**READY**

## Description
Gaussian smoothing is performed previous to the scaling operation if
zoom factor < 1. This reduces the aliasing introduced by the
undersampling operation.

Choice of sigma according to:
    Cardoso et al., "Scale factor point spread function matching:
    beyond aliasing in image resampling", MICCAI 2015

Currently, labels are also smoothed. I wonder if there are disadvantages to this.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.


## Impacted Areas in Application
* Spatial scaling


Closes #242 