### PR TITLE
Add transfer learning

### DIFF
--- a/doc/source/transfer_learning.md
+++ b/doc/source/transfer_learning.md
@@ -65,9 +65,9 @@ their name (the '|' acts like a boolean OR).
 
 **For excluding a few variables:**
 
-`^((?!DenseVNet\/(conv|batch_norm)).)*$` = don't match any vars that contain
-*DenseVNet/conv* or *DenseVNet/batch_norm* in their name (the '\' is an escape
-character for '/').
+`^((?!DenseVNet\/(skip_conv|fin_conv)).)*$` = don't match any vars that contain
+*DenseVNet/skip_conv* or *DenseVNet/fin_conv* in their name (the '\' is an
+escape character for '/').
 
 Once you've created a regex expression, it's recommended that you use a tool
 like [RegEx101](https://regex101.com) to double check that it works as
@@ -85,12 +85,15 @@ layers of a network while leaving the pre-trained feature extractors intact.
 While `freeze_restored_vars` does not allow you to pick and choose which vars
 to optimise, it stills offers quite a bit of flexibility. For example, when
 adapting your network to a new task your can first freeze your feature
-extractors until your top layers are reasonably well trained. Then you can stop training, unfreeze all layers and proceed to fine-tune the whole network
+extractors until your top layers are reasonably well trained. Then you can stop
+training, unfreeze all layers and proceed to fine-tune the whole network
 with a lower learning rate.
+
 
 ### *Notes*
 
-- Transfer learning in NiftyNet only works between networks using the exact same
-graph. Therefore you cannot initialize variables with weights from a random
-pre-trained VGG net for example, unless they share all of the same variables
-and they are named the same.
+- Transfer learning in NiftyNet will work between any networks that share the
+exact same variables as those being restored. In other words, you can change
+network layers that you plan to randomise but if you try to restore variables
+that aren't the exact shape and name between models, Tensorflow will throw an
+error.

--- a/doc/source/transfer_learning.md
+++ b/doc/source/transfer_learning.md
@@ -1,14 +1,15 @@
 # Transfer learning
 
-With NiftyNet, it's possible to initialize a model with pre-trained weights and
-adapt it to perform a different task. This functionality is provided through two
-config file parameters: `vars_to_restore` and `freeze_restored_vars`.
+With NiftyNet, it's possible to initialize your neural net with pre-trained
+variables and then fine-tune it for a seperate but similar task. This
+functionality is provided through two config file parameters: `vars_to_restore`
+and `freeze_restored_vars`.
 
 ### Setting up your model directory
 
 To fine-tune your model on a new dataset, first create a new model directory and
 specify its location through the `model_dir` parameter in your config file.
-Inside your model_dir directory create a folder named *models* and place the
+Inside your `model_dir` directory create a folder named `models` and place the
 three checkpoint files which constitue your model inside. Your directory
 structure should look like this:
 
@@ -23,10 +24,10 @@ model_dir/
 You can specify which checkpoint sources the pre-trained variables by
 setting the `starting_iter` parameter in your config file. The `starting_iter`
 should be set to either the `###` in your checkpoint filenames or -1, which will
-use the latest model in the *models* folder. You can freely change the `###` in
-the filenames to anything you want, however setting it to 0 will create a new
-model with randomized variables. Just change `###` to 1 if you want a fresh
-iteration counter.
+use the latest model in the `models` folder. You can freely change `###` in
+the filenames to anything you want, however specifying 0 will cause NiftyNet
+to ignore existing models and create a new model with randomized variables.
+Just change `###` to 1 if you want a fresh iteration counter.
 
 ### Selecting variables to restore
 
@@ -58,12 +59,12 @@ Once you've determined which variables you plan to restore, you must write a
 regex which will match them. If you have little experience with regex, here are
 a few examples to get you started:
 
-**For matching a few variables:**
+**For matching variables:**
 
 `^.*(conv_1|conv_2).*$` = match all vars that have *conv_1* or *conv_2* in
 their name (the '|' acts like a boolean OR).
 
-**For excluding a few variables:**
+**For excluding variables:**
 
 `^((?!DenseVNet\/(skip_conv|fin_conv)).)*$` = don't match any vars that contain
 *DenseVNet/skip_conv* or *DenseVNet/fin_conv* in their name (the '\' is an
@@ -71,9 +72,9 @@ escape character for '/').
 
 Once you've created a regex expression, it's recommended that you use a tool
 like [RegEx101](https://regex101.com) to double check that it works as
-expected. Set the test string as the variable names returned by the
-`get_ckpt_vars()` function above. If it checks out, set `vars_to_restore` to
-your regex.
+expected. Set the test string as the list of variable names returned by
+`get_ckpt_vars()`. If the regex successfuly selects the lines you intended, then
+you can use it to set `vars_to_restore`.
 
 
 ### Freezing model weights
@@ -90,10 +91,24 @@ training, unfreeze all layers and proceed to fine-tune the whole network
 with a lower learning rate.
 
 
-### *Notes*
+### Common Pitfalls
 
-- Transfer learning in NiftyNet will work between any networks that share the
-exact same variables as those being restored. In other words, you can change
+Transfer learning in NiftyNet will work between any models that share the same variables as those being restored. In other words, you can completely change
 network layers that you plan to randomise but if you try to restore variables
-that aren't the exact shape and name between models, Tensorflow will throw an
-error.
+that aren't the exact shape and name between models, Tensorflow and NiftyNet
+will throw an error. For example, you may encounter the following error in your
+training log:
+
+```
+CRITICAL:niftynet:2018-10-24 00:53:22,438: checkpoint ~/outputs/models/
+model.ckpt-### not found or variables to restore do not match the current
+application graph
+```
+
+This means that certain variables in your network are not present in your model checkpoint. Often this can occur unexpectedly when you restore variables that
+were frozen during the previous round of training. Since these variables weren't
+being trained, optimizer specific variables used in methods like Adam were never
+created and therefore never saved in the checkpoint. You can overcome this by
+simply restoring all variables except for those used by Adam: `vars_to_restore =
+^((?!(Adam)).)*$`. In general, if you read the error thrown by Tensorflow, you
+should be able to figure out which variables are causing the problem.

--- a/doc/source/transfer_learning.md
+++ b/doc/source/transfer_learning.md
@@ -1,0 +1,96 @@
+# Transfer learning
+
+With NiftyNet, it's possible to initialize a model with pre-trained weights and
+adapt it to perform a different task. This functionality is provided through two
+config file parameters: `vars_to_restore` and `freeze_restored_vars`.
+
+### Setting up your model directory
+
+To fine-tune your model on a new dataset, first create a new model directory and
+specify its location through the `model_dir` parameter in your config file.
+Inside your model_dir directory create a folder named *models* and place the
+three checkpoint files which constitue your model inside. Your directory
+structure should look like this:
+
+```
+model_dir/  
+  models/  
+    model.ckpt-###.data-00000-of-00001  
+    model.ckpt-###.index  
+    model.ckpt-###.meta
+```
+
+You can specify which checkpoint sources the pre-trained variables by
+setting the `starting_iter` parameter in your config file. The `starting_iter`
+should be set to either the `###` in your checkpoint filenames or -1, which will
+use the latest model in the *models* folder. You can freely change the `###` in
+the filenames to anything you want, however setting it to 0 will create a new
+model with randomized variables. Just change `###` to 1 if you want a fresh
+iteration counter.
+
+### Selecting variables to restore
+
+Next we must decide which variables we would like to restore. The
+`vars_to_restore` parameter allows you to specify a regular expression that
+will match variable names in a checkpoint file. Only variable names matched by
+the regex will be restored by NiftyNet while the rest are initialized to
+random values.
+
+You can obtain a list of all the variables in your model using the following
+bit of code:
+
+```python
+import tensorflow as tf
+
+# ckpt_path: full path to checkpoint file (ex: /path/to/ckpt/model.ckpt-###)
+# output_file: name of output file (ex: /path/to/file/net_vars.txt)
+def get_ckpt_vars(ckpt_path, output_file):
+    file = open(output_file, 'w+')
+    for var in tf.train.list_variables(ckpt_path):
+        file.write(str(var) + '\n')
+    file.close()
+
+get_ckpt_vars('~/Desktop/model_outputs/models/model.ckpt-1', \
+              '~/Desktop/net_vars.txt')
+```
+
+Once you've determined which variables you plan to restore, you must write a
+regex which will match them. If you have little experience with regex, here are
+a few examples to get you started:
+
+**For matching a few variables:**
+
+`^.*(conv_1|conv_2).*$` = match all vars that have *conv_1* or *conv_2* in
+their name (the '|' acts like a boolean OR).
+
+**For excluding a few variables:**
+
+`^((?!DenseVNet\/(conv|batch_norm)).)*$` = don't match any vars that contain
+*DenseVNet/conv* or *DenseVNet/batch_norm* in their name (the '\' is an escape
+character for '/').
+
+Once you've created a regex expression, it's recommended that you use a tool
+like [RegEx101](https://regex101.com) to double check that it works as
+expected. Set the test string as the variable names returned by the
+`get_ckpt_vars()` function above. If it checks out, set `vars_to_restore` to
+your regex.
+
+
+### Freezing model weights
+
+If you only wish to optimise the randomized variables of your network, you can
+set `freeze_restored_vars` to **True**. This is useful for only training the top
+layers of a network while leaving the pre-trained feature extractors intact.
+
+While `freeze_restored_vars` does not allow you to pick and choose which vars
+to optimise, it stills offers quite a bit of flexibility. For example, when
+adapting your network to a new task your can first freeze your feature
+extractors until your top layers are reasonably well trained. Then you can stop training, unfreeze all layers and proceed to fine-tune the whole network
+with a lower learning rate.
+
+### *Notes*
+
+- Transfer learning in NiftyNet only works between networks using the exact same
+graph. Therefore you cannot initialize variables with weights from a random
+pre-trained VGG net for example, unless they share all of the same variables
+and they are named the same.

--- a/niftynet/application/segmentation_application.py
+++ b/niftynet/application/segmentation_application.py
@@ -330,8 +330,8 @@ class SegmentationApplication(BaseApplication):
                 # Only optimise vars that weren't restored
                 to_optimise = \
                     [v for v in var_list if not var_regex.search(v.name)]
-                tf.logging.info("Optimizing the following variables: {}".format(
-                    str([v.name + '\n' for v in to_optimise])))
+                tf.logging.info("Optimizing {} variables".format(
+                    len(to_optimise])))
             else:
                 # Optimize all vars
                 to_optimise = var_list

--- a/niftynet/application/segmentation_application.py
+++ b/niftynet/application/segmentation_application.py
@@ -331,7 +331,7 @@ class SegmentationApplication(BaseApplication):
                 to_optimise = \
                     [v for v in var_list if not var_regex.search(v.name)]
                 tf.logging.info("Optimizing {} variables".format(
-                    len(to_optimise])))
+                    len(to_optimise)))
             else:
                 # Optimize all vars
                 to_optimise = var_list

--- a/niftynet/application/segmentation_application.py
+++ b/niftynet/application/segmentation_application.py
@@ -321,21 +321,24 @@ class SegmentationApplication(BaseApplication):
             else:
                 loss = data_loss
 
+            # Get all vars
             var_list = tf.global_variables()
-            if action_param.freeze_restored_vars \
-                and action_param.vars_to_restore:
+            if self.action_param.freeze_restored_vars and \
+                self.action_param.vars_to_restore:
                 import re
-                var_regex = re.compile(action_param.vars_to_restore)
+                var_regex = re.compile(self.action_param.vars_to_restore)
                 # Only optimise vars that weren't restored
                 to_optimise = \
                     [v for v in var_list if not var_regex.search(v.name)]
-                tf.logging.info("Optimizing the following variables: ")
-                tf.logging.info([v.name for v in to_optimise])
+                tf.logging.info("Optimizing the following variables: {}".format(
+                    str([v.name + '\n' for v in to_optimise])))
             else:
+                # Optimize all vars
                 to_optimise = var_list
 
-            grads = self.optimiser.compute_gradients(
-                loss, colocate_gradients_with_ops=True, var_list=to_optimise)
+            grads = self.optimiser.compute_gradients(loss, var_list=to_optimise,
+                colocate_gradients_with_ops=True)
+
             # collecting gradients variables
             gradients_collector.add_to_collection([grads])
             # collecting output variables

--- a/niftynet/engine/application_driver.py
+++ b/niftynet/engine/application_driver.py
@@ -110,6 +110,7 @@ class ApplicationDriver(object):
             self.max_checkpoints = max(self.max_checkpoints,
                                        train_param.max_checkpoints)
             self.validation_every_n = train_param.validation_every_n
+            self.vars_to_restore = train_param.vars_to_restore
             if self.validation_every_n > 0:
                 self.validation_max_iter = max(self.validation_max_iter,
                                                train_param.validation_max_iter)

--- a/niftynet/engine/application_driver.py
+++ b/niftynet/engine/application_driver.py
@@ -134,9 +134,10 @@ class ApplicationDriver(object):
         self.data_partitioner.reset()
         if data_param:
             do_new_partition = \
-                self.is_training_action and self.initial_iter == 0 and \
+                (self.initial_iter == 0 or self.vars_to_restore) and \
+                self.is_training_action and \
                 (not os.path.isfile(system_param.dataset_split_file)) and \
-                (train_param.exclude_fraction_for_validation > 0 or
+                (train_param.exclude_fraction_for_validation > 0 or \
                  train_param.exclude_fraction_for_inference > 0)
             data_fractions = (train_param.exclude_fraction_for_validation,
                               train_param.exclude_fraction_for_inference) \

--- a/niftynet/engine/application_driver.py
+++ b/niftynet/engine/application_driver.py
@@ -134,7 +134,6 @@ class ApplicationDriver(object):
         self.data_partitioner.reset()
         if data_param:
             do_new_partition = \
-                (self.initial_iter == 0 or self.vars_to_restore) and \
                 self.is_training_action and \
                 (not os.path.isfile(system_param.dataset_split_file)) and \
                 (train_param.exclude_fraction_for_validation > 0 or \

--- a/niftynet/engine/handler_model.py
+++ b/niftynet/engine/handler_model.py
@@ -70,7 +70,7 @@ class ModelRestorer(object):
         :return:
         """
 
-        tf.logging.info("Deciding which variables to restore...")
+        tf.logging.info("Finding variables to restore...")
 
         # Get all vars
         var_list = tf.global_variables()
@@ -86,8 +86,8 @@ class ModelRestorer(object):
                 else:
                     to_randomise.append(v)
 
-            tf.logging.info("Randomizing the following variables: {}".format(
-                str([v.name + '\n' for v in to_randomise])))
+            tf.logging.info("Randomizing {} variables".format(
+                len(to_randomise])))
             # Initialize vars to randomize
             init_op = tf.variables_initializer(to_randomise)
             tf.get_default_session().run(init_op)
@@ -95,7 +95,8 @@ class ModelRestorer(object):
             # Restore all vars
             to_restore = var_list
 
-        tf.logging.info('Restoring other vars from iter %d', self.initial_iter)
+        tf.logging.info('Restoring %d variables from iter %d',
+            len(to_restore), self.initial_iter)
         checkpoint = '{}-{}'.format(self.file_name_prefix, self.initial_iter)
         tf.logging.info('Accessing %s', checkpoint)
 

--- a/niftynet/engine/handler_model.py
+++ b/niftynet/engine/handler_model.py
@@ -87,7 +87,7 @@ class ModelRestorer(object):
                     to_randomise.append(v)
 
             tf.logging.info("Randomizing {} variables".format(
-                len(to_randomise])))
+                len(to_randomise)))
             # Initialize vars to randomize
             init_op = tf.variables_initializer(to_randomise)
             tf.get_default_session().run(init_op)

--- a/niftynet/utilities/user_parameters_default.py
+++ b/niftynet/utilities/user_parameters_default.py
@@ -599,6 +599,18 @@ def add_training_args(parser):
         type=float,
         default=0.)
 
+    parser.add_argument(
+        "--vars_to_restore",
+        help="regex strings matching variable names to restore",
+        type=str,
+        default='')
+
+    parser.add_argument(
+        "--freeze_restored_vars",
+        help="Indicates whether to continue training restored variables",
+        type=str2boolean,
+        default=False)
+
     return parser
 
 


### PR DESCRIPTION
## Status
**READY**

## Description
This pull request adds a simple interface for performing transfer learning with NiftyNet. In addition, it provides documentation to guide novice users step-by-step through the process.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Ability to specify which variable's to restore from a model checkpoint through the vars_to_restore parameter in the config file. User employs regular expressions to match the desired variables.
- [x] Option to freeze the variables which were restored using the freeze_restored_vars parameter in the config file.
- [x] Guide and documentation for using transfer learning in NiftyNet
- [x] Function for printing all variable names in a model checkpoint.

## Todos
- [ ] Tests
- [ ] Add additional flexibility


## Impacted Areas in Application
* Model restoration
* Default user parameters

