### PR TITLE
Add option to use isotropic random scaling

### DIFF
--- a/doc/source/config_spec.md
+++ b/doc/source/config_spec.md
@@ -194,7 +194,7 @@ See also: [Patch-base analysis guide](./window_sizes.html)
 ###### `loader`
 Specify the loader to be used to load the files in the input section.
 Some loaders require additional Python packages.
-Supported loaders: `nibabel`, `opencv`, `skimage`, `pillow`, `simpleitk`, `dummy` in prioriy order. 
+Supported loaders: `nibabel`, `opencv`, `skimage`, `pillow`, `simpleitk`, `dummy` in prioriy order.
 Default value `None` indicates trying all available loaders, in the above priority order.
 
 This section will be used by [ImageReader](./niftynet.io.image_reader.html)
@@ -258,9 +258,9 @@ This option is ignored if there's no GPU device.
 Directory to save/load intermediate training models and logs.  NiftyNet tries
 to interpret this parameter as an absolute system path or a path relative to
 the current command.  It's defaulting to the directory of the current
-configuration file if left blank. 
+configuration file if left blank.
 
-It is assumed that `model_dir` contains two folders, `models` and `logs`. 
+It is assumed that `model_dir` contains two folders, `models` and `logs`.
 
 ######  `dataset_split_file`
 File assigning subjects to training/validation/inference subsets.
@@ -595,6 +595,7 @@ Value should be in `[0, 1]`.
 [rotation_angle](#rotation-angle) | `float array` | `rotation_angle=-10.0,10.0` | `''`
 [scaling_percentage](#scaling-percentage) | `float array` | `scaling_percentage=-20.0,20.0` | `''`
 [antialiasing](#scaling-percentage) | `boolean` | `antialiasing=True` | `True`
+[isotropic_scaling](#scaling-percentage) | `boolean` | `isotropic_scaling=True` | `False`
 [random_flipping_axes](#random-flipping-axes) | `integer array` | `random_flipping_axes=1,2` | `-1`
 [do_elastic_deformation](#do-elastic-deformation) | `boolean` | `do_elastic_deformation=True` | `False`
 [num_ctrl_points](#do-elastic-deformation) | `integer` | `num_ctrl_points=1` | `4`
@@ -616,8 +617,10 @@ E.g, `(-50, 50)` indicates transforming
 image (size `d`) to image with its size in between `0.5*d` and `1.5d`.
 
 When random scaling is enabled, it is possible to further specify:
-- `antialiasing` indicating if antialiasing should be performed
+- `antialiasing` indicating if Gaussian filtering should be performed
 when randomly downsampling the input images.
+- `isotropic_scaling` indicating if the same amount of scaling should be applied
+in each dimension.
 
 ###### `random_flipping_axes`
 The axes which can be flipped to augment the data.
@@ -682,7 +685,7 @@ Interpolation order of the network outputs.
 ###### `dataset_to_infer`
 String specifies which dataset ('all', 'training', 'validation', 'inference') to compute inference for.
 By default 'inference' dataset is used. If no `dataset_split_file` is specified, then all data specified
-in the csv or search path are used for inference. 
+in the csv or search path are used for inference.
 
 
 ### EVALUATION

--- a/niftynet/application/classification_application.py
+++ b/niftynet/application/classification_application.py
@@ -136,7 +136,8 @@ class ClassificationApplication(BaseApplication):
                 augmentation_layers.append(RandomSpatialScalingLayer(
                     min_percentage=train_param.scaling_percentage[0],
                     max_percentage=train_param.scaling_percentage[1],
-                    antialiasing=train_param.antialiasing))
+                    antialiasing=train_param.antialiasing,
+                    isotropic=train_param.isotropic_scaling))
             if train_param.rotation_angle or \
                     self.action_param.rotation_angle_x or \
                     self.action_param.rotation_angle_y or \

--- a/niftynet/application/gan_application.py
+++ b/niftynet/application/gan_application.py
@@ -104,7 +104,8 @@ class GANApplication(BaseApplication):
                 augmentation_layers.append(RandomSpatialScalingLayer(
                     min_percentage=self.action_param.scaling_percentage[0],
                     max_percentage=self.action_param.scaling_percentage[1],
-                    antialiasing=self.action_param.antialiasing))
+                    antialiasing=self.action_param.antialiasing,
+                    isotropic=self.action_param.isotropic_scaling))
             if self.action_param.rotation_angle:
                 augmentation_layers.append(RandomRotationLayer())
                 augmentation_layers[-1].init_uniform_angle(

--- a/niftynet/application/regression_application.py
+++ b/niftynet/application/regression_application.py
@@ -125,7 +125,8 @@ class RegressionApplication(BaseApplication):
                 augmentation_layers.append(RandomSpatialScalingLayer(
                     min_percentage=train_param.scaling_percentage[0],
                     max_percentage=train_param.scaling_percentage[1],
-                    antialiasing=train_param.antialiasing))
+                    antialiasing=train_param.antialiasing,
+                    isotropic=train_param.isotropic_scaling))
             if train_param.rotation_angle:
                 rotation_layer = RandomRotationLayer()
                 if train_param.rotation_angle:

--- a/niftynet/application/segmentation_application.py
+++ b/niftynet/application/segmentation_application.py
@@ -151,7 +151,8 @@ class SegmentationApplication(BaseApplication):
                 augmentation_layers.append(RandomSpatialScalingLayer(
                     min_percentage=train_param.scaling_percentage[0],
                     max_percentage=train_param.scaling_percentage[1],
-                    antialiasing=train_param.antialiasing))
+                    antialiasing=train_param.antialiasing,
+                    isotropic=train_param.isotropic_scaling))
             if train_param.rotation_angle or \
                     train_param.rotation_angle_x or \
                     train_param.rotation_angle_y or \

--- a/niftynet/contrib/preprocessors/preprocessing.py
+++ b/niftynet/contrib/preprocessors/preprocessing.py
@@ -58,7 +58,8 @@ class Preprocessing:
             augmentation_layers.append(RandomSpatialScalingLayer(
                 min_percentage=self.action_param.scaling_percentage[0],
                 max_percentage=self.action_param.scaling_percentage[1],
-                antialiasing=self.action_param.antialiasing))
+                antialiasing=self.action_param.antialiasing,
+                isotropic=self.action_param.isotropic_scaling))
         if self.action_param.rotation_angle or \
                 self.action_param.rotation_angle_x or \
                 self.action_param.rotation_angle_y or \

--- a/niftynet/layer/rand_spatial_scaling.py
+++ b/niftynet/layer/rand_spatial_scaling.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, print_function
 
 import warnings
 
+import tensorflow as tf
 import numpy as np
 import scipy.ndimage as ndi
 
@@ -21,19 +22,26 @@ class RandomSpatialScalingLayer(RandomisedLayer):
                  min_percentage=-10.0,
                  max_percentage=10.0,
                  antialiasing=True,
+                 isotropic=True,
                  name='random_spatial_scaling'):
         super(RandomSpatialScalingLayer, self).__init__(name=name)
         assert min_percentage <= max_percentage
         self._min_percentage = max(min_percentage, -99.9)
         self._max_percentage = max_percentage
         self.antialiasing = antialiasing
+        self.isotropic = isotropic
         self._rand_zoom = None
 
     def randomise(self, spatial_rank=3):
         spatial_rank = int(np.floor(spatial_rank))
-        rand_zoom = np.random.uniform(low=self._min_percentage,
-                                      high=self._max_percentage,
-                                      size=(spatial_rank,))
+        if self.isotropic:
+            one_rand_zoom = np.random.uniform(low=self._min_percentage,
+                                              high=self._max_percentage)
+            rand_zoom = np.repeat(one_rand_zoom, spatial_rank)
+        else:
+            rand_zoom = np.random.uniform(low=self._min_percentage,
+                                          high=self._max_percentage,
+                                          size=(spatial_rank,))
         self._rand_zoom = (rand_zoom + 100.0) / 100.0
 
     def _get_sigma(self, zoom):

--- a/niftynet/layer/rand_spatial_scaling.py
+++ b/niftynet/layer/rand_spatial_scaling.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, print_function
 
 import warnings
 
-import tensorflow as tf
 import numpy as np
 import scipy.ndimage as ndi
 
@@ -22,7 +21,7 @@ class RandomSpatialScalingLayer(RandomisedLayer):
                  min_percentage=-10.0,
                  max_percentage=10.0,
                  antialiasing=True,
-                 isotropic=True,
+                 isotropic=False,
                  name='random_spatial_scaling'):
         super(RandomSpatialScalingLayer, self).__init__(name=name)
         assert min_percentage <= max_percentage

--- a/niftynet/utilities/user_parameters_default.py
+++ b/niftynet/utilities/user_parameters_default.py
@@ -485,6 +485,13 @@ def add_training_args(parser):
         default=())
 
     parser.add_argument(
+        "--isotropic_scaling",
+        help="Indicates if the same random scaling factor should be applied "
+             "to each dimension",
+        type=str2boolean,
+        default=False)
+
+    parser.add_argument(
         "--antialiasing",
         help="Indicates if antialiasing must be performed "
              "when randomly scaling the input images",


### PR DESCRIPTION
## Status
**READY**

## Description
When performing random scaling, it might be desired to perform the same amount of scaling in every dimension. I have added an `isotropic_scaling` flag and added the corresponding feature.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


## Todos
- [ ] Tests
- [x] Documentation


## Impacted Areas in Application
List general components of the application that this PR will affect:
* Data augmentation
