### PR TITLE
amendment to regression application

### DIFF
--- a/niftynet/application/regression_application.py
+++ b/niftynet/application/regression_application.py
@@ -275,13 +275,21 @@ class RegressionApplication(BaseApplication):
                     learning_rate=self.action_param.lr)
             loss_func = LossFunction(loss_type=self.action_param.loss_type)
 
-            crop_layer = CropLayer(border=self.regression_param.loss_border)
             weight_map = data_dict.get('weight', None)
-            weight_map = None if weight_map is None else crop_layer(weight_map)
-            data_loss = loss_func(
-                prediction=crop_layer(net_out),
-                ground_truth=crop_layer(data_dict['output']),
-                weight_map=weight_map)
+            border=self.regression_param.loss_border
+            if border > 0:
+                crop_layer = CropLayer(border)
+                weight_map = None if weight_map is None else crop_layer(weight_map)
+                data_loss = loss_func(
+                        prediction=crop_layer(net_out),
+                        ground_truth=crop_layer(data_dict['output']),
+                        weight_map=weight_map)
+            else:
+                data_loss = loss_func(
+                        prediction=net_out,
+                        ground_truth=data_dict['output'],
+                        weight_map=weight_map)
+                
             reg_losses = tf.get_collection(tf.GraphKeys.REGULARIZATION_LOSSES)
             if self.net_param.decay > 0.0 and reg_losses:
                 reg_loss = tf.reduce_mean(


### PR DESCRIPTION
## Status
READY

## Description
Updated regression application to avoid cropping layer if loss border is 0. Currently the regression application fails if the output value being regressed is of size 1x1x1, throwing a shape error, as the crop layer expects the output to hold the same dimensions as the input image. The amendment allows the crop layer to be skipped in the case of a loss border equal to 0, which should be the case if the output is 1x1x1.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
