### PR TITLE
143 background fill value

### DIFF
--- a/niftynet/application/regression_application.py
+++ b/niftynet/application/regression_application.py
@@ -203,7 +203,8 @@ class RegressionApplication(BaseApplication):
             output_path=self.action_param.save_seg_dir,
             window_border=self.action_param.border,
             interp_order=self.action_param.output_interp_order,
-            postfix=self.action_param.output_postfix)
+            postfix=self.action_param.output_postfix,
+            fill_constant=self.action_param.fill_constant)
 
     def initialise_resize_aggregator(self):
         self.output_decoder = ResizeSamplesAggregator(

--- a/niftynet/application/segmentation_application.py
+++ b/niftynet/application/segmentation_application.py
@@ -237,7 +237,8 @@ class SegmentationApplication(BaseApplication):
             output_path=self.action_param.save_seg_dir,
             window_border=self.action_param.border,
             interp_order=self.action_param.output_interp_order,
-            postfix=self.action_param.output_postfix)
+            postfix=self.action_param.output_postfix,
+            fill_constant=self.action_param.fill_constant)
 
     def initialise_resize_aggregator(self):
         self.output_decoder = ResizeSamplesAggregator(

--- a/niftynet/engine/windows_aggregator_grid.py
+++ b/niftynet/engine/windows_aggregator_grid.py
@@ -28,7 +28,8 @@ class GridSamplesAggregator(ImageWindowsAggregator):
                  output_path=os.path.join('.', 'output'),
                  window_border=(),
                  interp_order=0,
-                 postfix='_niftynet_out'):
+                 postfix='_niftynet_out',
+                 fill_constant=0.0):
         ImageWindowsAggregator.__init__(
             self, image_reader=image_reader, output_path=output_path)
         self.name = name
@@ -36,6 +37,7 @@ class GridSamplesAggregator(ImageWindowsAggregator):
         self.window_border = window_border
         self.output_interp_order = interp_order
         self.postfix = postfix
+        self.fill_constant = fill_constant
 
     def decode_batch(self, window, location):
         n_samples = location.shape[0]
@@ -68,6 +70,10 @@ class GridSamplesAggregator(ImageWindowsAggregator):
         for layer in self.reader.preprocessors:
             if isinstance(layer, PadLayer):
                 empty_image, _ = layer(empty_image)
+
+        if self.fill_constant != 0.0:
+            empty_image[:] = self.fill_constant
+
         return empty_image
 
     def _save_current_image(self):

--- a/niftynet/utilities/user_parameters_default.py
+++ b/niftynet/utilities/user_parameters_default.py
@@ -148,6 +148,12 @@ def add_inference_args(parser):
         type=spatialnumarray,
         default=(0, 0, 0))
 
+    parser.add_argument(
+        "--fill-constant",
+        help="Output fill value used fill borders of output images.",
+        type=float,
+        default=0.0)
+
     return parser
 
 

--- a/niftynet/utilities/user_parameters_default.py
+++ b/niftynet/utilities/user_parameters_default.py
@@ -150,7 +150,7 @@ def add_inference_args(parser):
 
     parser.add_argument(
         "--fill-constant",
-        help="Output fill value used fill borders of output images.",
+        help="[Inference only] Output fill value used fill borders of output images.",
         type=float,
         default=0.0)
 


### PR DESCRIPTION
## Status
**READY**

## Description
Satisfies the requirements of ticket 143, in many(/most?) situations, by initialising the output image buffer in `GridSamplesAggregator` to a user specifiable value. However, that fill value may not survive certain post-processing operations  applied after the batches have been aggregated into the final image (e.g., `DiscreteLabelNormalisationLayer` will modify those default values).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


## Todos
- [x] Tests
- [x] Documentation: may require an updating of the [NiftyNet config manual](https://niftynet.readthedocs.io/en/dev/config_spec.html)


## Impacted Areas in Application
List general components of the application that this PR will affect:
* niftynet.engine.windows_aggregator_grid.GridSamplesAggregator
* niftynet.utilities.user_parameters_default
