### PR TITLE
279: super-resolution based on Real-Time Single Image and Video Super-Resolution Using an Efficient Sub-Pixel Convolutional Neural  Network

### DIFF
--- a/niftynet/layer/subpixel.py
+++ b/niftynet/layer/subpixel.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, print_function
+
+import tensorflow as tf
+
+from niftynet.layer import layer_util
+from niftynet.layer.base_layer import TrainableLayer
+from niftynet.layer.convolution import ConvolutionalLayer
+
+class SubPixelLayer(TrainableLayer):
+    """
+    Implementation of Shi et al.'s sub-pixel CNN single-image
+    upsampling method.
+
+    Based on Shi et al.: "Real-Time Single Image and Video
+    Super-Resolution Using an Efficient Sub-Pixel Convolutional Neural
+    Network"
+    """
+
+    def __init__(self,
+                 upsample_factor=3,
+                 layer_configurations=((5, 64),
+                                       (3, 32),
+                                       (3, -1)),
+                 acti_func='tanh',
+                 with_bn=False,
+                 with_bias=True,
+                 padding='REFLECT',
+                 w_initializer=None,
+                 w_regularizer=None,
+                 b_initializer=None,
+                 b_regularizer=None,
+                 name='subpixel_cnn'):
+        """
+        :param upsample_factor: zoom-factor/image magnification factor
+        :param layer_configurations: N pairs consisting of a kernel size and
+        a feature-map size, where N is the number of layers in the net. The last
+        layer must have a feature-map size of -1.
+        :param padding: padding applied in convolutional layers
+        :param with_bias: incorporate bias parameters in convolutional layers
+        :param with_bn: incorporate batch normalisation in convolutional layers
+        :param acti_func: activation function applied to first N - 1 layers
+        """
+
+        super(SubPixelLayer, self).__init__(name=name)
+
+        if layer_configurations[-1][1] != -1:
+            raise ValueError('The size of the last feature map must be -1')
+        if upsample_factor <= 0:
+            raise ValueError('The upsampling factor must be strictly positive.')
+
+        self.upsample_factor = upsample_factor
+        self.layer_configurations = layer_configurations
+        self.acti_func = acti_func
+
+        self.conv_layer_params = {'with_bias': with_bias,
+                                  'with_bn': with_bn,
+                                  'padding': padding,
+                                  'w_initializer': w_initializer,
+                                  'b_initializer': b_initializer,
+                                  'w_regularizer': w_regularizer,
+                                  'b_regularizer': b_regularizer}
+
+    def layer_op(self, lr_images, is_training=True, keep_prob=1.0):
+        input_shape = lr_images.shape.as_list()
+        batch_size = input_shape[0]
+        input_shape = input_shape[1:]
+        nof_dims = len(input_shape) - 1
+
+        if batch_size is None:
+            raise ValueError('The batch size must be known and fixed.')
+        if any(i is None or i <= 0 for i in input_shape):
+            raise ValueError('The image shape must be known in advance.')
+
+        nof_channels = input_shape[-1]
+
+        features = lr_images
+        for i, (ksize, nof_features) in enumerate(self.layer_configurations):
+            name = 'fmap_{}'.format(i)
+
+            if nof_features > 0:
+                conv = ConvolutionalLayer(nof_features,
+                                          kernel_size=ksize,
+                                          acti_func=self.acti_func,
+                                          name=name,
+                                          **self.conv_layer_params)
+            else:
+                nof_features = nof_channels*self.upsample_factor**nof_dims
+                conv = ConvolutionalLayer(nof_features,
+                                          kernel_size=ksize,
+                                          acti_func=None,
+                                          name=name,
+                                          **self.conv_layer_params)
+
+            features = conv(features, is_training=is_training,
+                            keep_prob=keep_prob)
+
+        # Setting the number of output features to the known value
+        # obtained from the input shape results in a ValueError as
+        # of TF 1.12
+        output_shape = [batch_size] \
+            + [self.upsample_factor*i for i in input_shape[:-1]] \
+            + [None]
+
+        return tf.contrib.periodic_resample.periodic_resample(features,
+                                                              output_shape,
+                                                              name='shuffle')

--- a/tests/subpixel_test.py
+++ b/tests/subpixel_test.py
@@ -1,0 +1,94 @@
+from __future__ import division, absolute_import, print_function
+
+import functools as ft
+import numpy as np
+import tensorflow as tf
+
+from niftynet.layer.subpixel import SubPixelLayer
+
+class SubPixelTest(tf.test.TestCase):
+    """
+    Test for niftynet.layer.subpixel.SubPixelLayer.
+    Mostly adapted from convolution_test.py
+    """
+
+    def get_3d_input(self):
+        input_shape = (2, 16, 16, 16, 8)
+        x_3d = tf.ones(input_shape)
+        return x_3d
+
+    def get_2d_input(self):
+        input_shape = (2, 16, 16, 8)
+        x_2d = tf.ones(input_shape)
+        return x_2d
+
+    def _test_subpixel_output_shape(self,
+                                    input_data,
+                                    param_dict,
+                                    output_shape):
+
+        layer = SubPixelLayer(**param_dict)
+        output_data = layer(input_data)
+        print(layer)
+        with self.test_session() as sess:
+            sess.run(tf.global_variables_initializer())
+            output_value = sess.run(output_data)
+            self.assertAllClose(output_shape, output_value.shape)
+
+    def _make_output_shape(self, data, upsampling):
+        data_shape = data.shape.as_list()
+        output_shape = [data_shape[0]]
+        output_shape += [upsampling*d for d in data_shape[1:-1]]
+        output_shape += [data_shape[-1]]
+
+        return output_shape
+
+    def test_3d_default(self):
+        data = self.get_3d_input()
+
+        output_shape = self._make_output_shape(data, 3)
+
+        self._test_subpixel_output_shape(data,
+                                         {},
+                                         output_shape)
+
+
+    def test_3d_bespoke(self):
+        data = self.get_3d_input()
+        upsampling = 4
+
+        output_shape = self._make_output_shape(data, upsampling)
+
+        params = {'upsample_factor': upsampling,
+                  'layer_configurations': ((6, 32),
+                                           (3, 32),
+                                           (2, 16),
+                                           (4, -1)),
+                  'padding': 'SAME'}
+
+        self._test_subpixel_output_shape(data,
+                                         params,
+                                         output_shape)
+
+
+
+    def test_2d_bespoke(self):
+        data = self.get_2d_input()
+        upsampling = 6
+
+        output_shape = self._make_output_shape(data, upsampling)
+
+        params = {'upsample_factor': upsampling,
+                  'layer_configurations': ((6, 32),
+                                           (3, 32),
+                                           (2, 16),
+                                           (4, -1)),
+                  'padding': 'SAME'}
+
+        self._test_subpixel_output_shape(data,
+                                         params,
+                                         output_shape)
+
+
+if __name__ == "__main__":
+    tf.test.main()


### PR DESCRIPTION
## Status
**READY**

## Description
An implementation of the network mentioned in the title, and in ticket 279. Provides a means of upsampling tensors through a purely convolutional (sub-) network. Cannot be trained or used for inference with NiftyNet, directly, and is therefore only usable as a network building block.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


## Impacted Areas in Application
List general components of the application that this PR will affect:
* niftynet.layer (new layer class, does not break or otherwise interfere with anything).
