### PR TITLE
Fixes resize aggregator border

### DIFF
--- a/niftynet/engine/windows_aggregator_base.py
+++ b/niftynet/engine/windows_aggregator_base.py
@@ -111,10 +111,11 @@ class ImageWindowsAggregator(object):
             tf.logging.fatal(
                 'network output window can be '
                 'cropped by specifying the border parameter in config file, '
-                'but here the output window %s is already smaller '
-                'than the input window size minus padding: %s, '
-                'not supported by this aggregator',
-                spatial_shape, cropped_shape)
+                'but here the output window content size %s is smaller '
+                'than the window coordinate size: %s -- '
+                'computed by input window size minus border size (%s)'
+                'not supported by this aggregator. Please try larger border.)',
+                spatial_shape, cropped_shape, border)
             raise ValueError
         if n_spatial == 1:
             window = window[:,

--- a/niftynet/engine/windows_aggregator_resize.py
+++ b/niftynet/engine/windows_aggregator_resize.py
@@ -42,6 +42,14 @@ class ResizeSamplesAggregator(ImageWindowsAggregator):
         location specifies the original input image (so that the
         interpolation order, original shape information retained in the
         generated outputs).
+
+        each network output window is first cropped to::
+
+            size=input_window_size - inference_border
+
+        then resized to original_image_size + volume_padding_size
+        then cropped by volume_padding_size
+        then written to file
         """
         n_samples = location.shape[0]
         window, location = self.crop_batch(window, location, self.window_border)
@@ -71,12 +79,12 @@ class ResizeSamplesAggregator(ImageWindowsAggregator):
         window_shape = resize_to
         while image_out.ndim < 5:
             image_out = image_out[..., np.newaxis, :]
-        if self.window_border and any([b > 0 for b in self.window_border]):
-            np_border = self.window_border
-            while len(np_border) < 5:
-                np_border = np_border + (0,)
-            np_border = [(b,) for b in np_border]
-            image_out = np.pad(image_out, np_border, mode='edge')
+        # if self.window_border and any([b > 0 for b in self.window_border]):
+        #     np_border = self.window_border
+        #     while len(np_border) < 5:
+        #         np_border = np_border + (0,)
+        #     np_border = [(b,) for b in np_border]
+        #     image_out = np.pad(image_out, np_border, mode='edge')
         image_shape = image_out.shape
         zoom_ratio = \
             [float(p) / float(d) for p, d in zip(window_shape, image_shape)]


### PR DESCRIPTION
## Status
**READY**

## Description
Fixes resize aggregator's resizing behaviour, when [inference] border > 0 and network's output dimensions smaller than the input.
see also https://groups.google.com/forum/#!topic/niftynet/Ifh1V9WsNnU

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.


## Impacted Areas in Application
List general components of the application that this PR will affect:
* windows_aggregator_resize.py
