### PR TITLE
Regression app amendment for output identity resizing

### DIFF
--- a/niftynet/application/regression_application.py
+++ b/niftynet/application/regression_application.py
@@ -283,13 +283,21 @@ class RegressionApplication(BaseApplication):
                     learning_rate=self.action_param.lr)
             loss_func = LossFunction(loss_type=self.action_param.loss_type)
 
-            crop_layer = CropLayer(border=self.regression_param.loss_border)
+            #crop_layer = CropLayer(border=self.regression_param.loss_border)
             weight_map = data_dict.get('weight', None)
-            weight_map = None if weight_map is None else crop_layer(weight_map)
-            data_loss = loss_func(
-                prediction=crop_layer(net_out),
-                ground_truth=crop_layer(data_dict['output']),
-                weight_map=weight_map)
+            border=self.regression_param.loss_border
+            if border > 0:
+                crop_layer = CropLayer(border)
+                weight_map = None if weight_map is None else crop_layer(weight_map)
+                data_loss = loss_func(
+                        prediction=crop_layer(net_out),
+                        ground_truth=crop_layer(data_dict['output']),
+                        weight_map=weight_map)
+            else:
+                data_loss = loss_func(
+                        prediction=net_out,
+                        ground_truth=data_dict['output'],
+                        weight_map=weight_map)
             reg_losses = tf.get_collection(tf.GraphKeys.REGULARIZATION_LOSSES)
             if self.net_param.decay > 0.0 and reg_losses:
                 reg_loss = tf.reduce_mean(

--- a/niftynet/application/regression_application.py
+++ b/niftynet/application/regression_application.py
@@ -235,7 +235,7 @@ class RegressionApplication(BaseApplication):
             self.SUPPORTED_SAMPLING[self.net_param.window_sampling][1]()
 
     def initialise_aggregator(self):
-        if self.net_param.force_identity_output_resizing:
+        if self.net_param.force_output_identity_resizing:
             self.initialise_identity_aggregator()
         else:
             self.SUPPORTED_SAMPLING[self.net_param.window_sampling][2]()

--- a/niftynet/application/regression_application.py
+++ b/niftynet/application/regression_application.py
@@ -29,6 +29,7 @@ from niftynet.layer.rgb_histogram_equilisation import \
     RGBHistogramEquilisationLayer
 from niftynet.evaluation.regression_evaluator import RegressionEvaluator
 from niftynet.layer.rand_elastic_deform import RandomElasticDeformationLayer
+from niftynet.engine.windows_aggregator_identity import WindowAsImageAggregator
 
 SUPPORTED_INPUT = set(['image', 'output', 'weight', 'sampler', 'inferred'])
 
@@ -220,6 +221,12 @@ class RegressionApplication(BaseApplication):
             window_border=self.action_param.border,
             interp_order=self.action_param.output_interp_order,
             postfix=self.action_param.output_postfix)
+        
+    def initialise_identity_aggregator(self):
+        self.output_decoder = WindowAsImageAggregator(
+                image_reader=self.readers[0],
+                output_path=self.action_param.save_seg_dir,
+                postfix=self.action_param.output_postfix)
 
     def initialise_sampler(self):
         if self.is_training:
@@ -228,7 +235,10 @@ class RegressionApplication(BaseApplication):
             self.SUPPORTED_SAMPLING[self.net_param.window_sampling][1]()
 
     def initialise_aggregator(self):
-        self.SUPPORTED_SAMPLING[self.net_param.window_sampling][2]()
+        if self.net_param.force_identity_output_resizing:
+            self.initialise_identity_aggregator()
+        else:
+            self.SUPPORTED_SAMPLING[self.net_param.window_sampling][2]()
 
     def initialise_network(self):
         w_regularizer = None
@@ -283,20 +293,19 @@ class RegressionApplication(BaseApplication):
                     learning_rate=self.action_param.lr)
             loss_func = LossFunction(loss_type=self.action_param.loss_type)
 
-            #crop_layer = CropLayer(border=self.regression_param.loss_border)
             weight_map = data_dict.get('weight', None)
             border=self.regression_param.loss_border
-            if border > 0:
+            if border == None or tf.reduce_sum(tf.abs(border)) == 0:
+                data_loss = loss_func(
+                        prediction=net_out,
+                        ground_truth=data_dict['output'],
+                        weight_map=weight_map)
+            else:
                 crop_layer = CropLayer(border)
                 weight_map = None if weight_map is None else crop_layer(weight_map)
                 data_loss = loss_func(
                         prediction=crop_layer(net_out),
                         ground_truth=crop_layer(data_dict['output']),
-                        weight_map=weight_map)
-            else:
-                data_loss = loss_func(
-                        prediction=net_out,
-                        ground_truth=data_dict['output'],
                         weight_map=weight_map)
             reg_losses = tf.get_collection(tf.GraphKeys.REGULARIZATION_LOSSES)
             if self.net_param.decay > 0.0 and reg_losses:

--- a/niftynet/engine/windows_aggregator_identity.py
+++ b/niftynet/engine/windows_aggregator_identity.py
@@ -85,7 +85,10 @@ class WindowAsImageAggregator(ImageWindowsAggregator):
     def _save_current_image(self, idx, filename, image):
         if image is None:
             return
-        uniq_name = "{}_{}{}.nii.gz".format(idx, filename, self.postfix)
+        if idx == 0:
+            uniq_name = "{}{}.nii.gz".format(filename, self.postfix)
+        else:
+            uniq_name = "{}_{}{}.nii.gz".format(idx, filename, self.postfix)
         misc_io.save_data_array(self.output_path, uniq_name, image, None)
         with open(self.inferred_csv, 'a') as csv_file:
             filename = os.path.join(self.output_path, filename)

--- a/niftynet/utilities/user_parameters_default.py
+++ b/niftynet/utilities/user_parameters_default.py
@@ -330,7 +330,7 @@ def add_network_args(parser):
         default='uniform')
     
     parser.add_argument(
-        "--force_identity_output_resizing",
+        "--force_output_identity_resizing",
         metavar=str2boolean,
         help="Forces the shape of the inferred output to match the "
         "input label shape rather than be resized to input image shape.",

--- a/niftynet/utilities/user_parameters_default.py
+++ b/niftynet/utilities/user_parameters_default.py
@@ -328,6 +328,13 @@ def add_network_args(parser):
         " 'resize': resize image to the patch size.",
         choices=['uniform', 'resize', 'balanced', 'weighted'],
         default='uniform')
+    
+    parser.add_argument(
+        "--force_identity_output_resizing",
+        metavar=str2boolean,
+        help="Forces the shape of the inferred output to match the "
+        "input label shape rather than be resized to input image shape.",
+        default=False)
 
     parser.add_argument(
         "--queue_length",

--- a/niftynet/utilities/user_parameters_default.py
+++ b/niftynet/utilities/user_parameters_default.py
@@ -328,7 +328,7 @@ def add_network_args(parser):
         " 'resize': resize image to the patch size.",
         choices=['uniform', 'resize', 'balanced', 'weighted'],
         default='uniform')
-    
+
     parser.add_argument(
         "--force_output_identity_resizing",
         metavar=str2boolean,


### PR DESCRIPTION
## Status
READY

## Description
1.Prevent cropping operation if the loss_border is None or 0. This is necessary in the case of regressing a single value of shape 1x1x1, where the use of cropping layer will throw a shape error.
2.Allow regression output to maintain label shape when the resize sampler is chosen, rather than resize the output back to image shape. Again, the motivation was the case of regressing a single value of shape 1x1x1, where it is desirable for the output to not be resized to image shape. This change involved adding a new config flag --force_output_identity_resizing and using this flag in the regression application to choose the identity aggregator.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


## Todos
- [ ] Tests
- [ ] Documentation


## Impacted Areas in Application
List general components of the application that this PR will affect:
*
