### PR TITLE
Fix issue when applying crf layer on batch_size>1

### DIFF
--- a/niftynet/layer/crf.py
+++ b/niftynet/layer/crf.py
@@ -327,8 +327,8 @@ def permutohedral_prepare(position_vectors):
     # linearised [batch, spatial_dim] indices
     # where in the splat variable each simplex vertex is
     batch_index = tf.range(batch_size, dtype=tf.int32)
-    batch_index = tf.expand_dims(batch_index, 0)
-    batch_index = tf.tile(batch_index, [n_voxels, 1])
+    batch_index = tf.expand_dims(batch_index, 1)
+    batch_index = tf.tile(batch_index, [1, n_voxels])
     batch_index = tf.to_int64(tf.reshape(batch_index, [-1]))
 
     indices = [None] * n_ch_1

--- a/tests/crf_test.py
+++ b/tests/crf_test.py
@@ -5,6 +5,7 @@ import numpy as np
 import tensorflow as tf
 
 from niftynet.layer.crf import CRFAsRNNLayer
+from niftynet.layer.crf import permutohedral_prepare, permutohedral_compute
 
 
 class CRFTest(tf.test.TestCase):
@@ -118,6 +119,22 @@ class CRFTest(tf.test.TestCase):
             sess.run(opt)
             params_1 = sess.run(tf.trainable_variables())
             self.assertGreater(np.sum(np.abs(params_1[0] - params[0])), 0.0)
+
+    def test_batch_mix(self):
+        feat = tf.random.uniform(shape=[2, 64, 5])
+        desc = tf.ones(shape=[1, 64, 1])
+        desc_ = tf.zeros(shape=[1, 64, 1])
+        desc = tf.concat([desc, desc_], axis=0)
+        barycentric, blur_neighbours1, blur_neighbours2, indices = permutohedral_prepare(feat)
+        sliced = permutohedral_compute(desc,
+                          barycentric,
+                          blur_neighbours1,
+                          blur_neighbours2,
+                          indices,
+                          "test",
+                          True)
+        self.assertAllClose(sliced[1:], tf.zeros(shape=[1, 64, 1]))
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This issue has not been reported, yet if you do simple test with this layer with batch larger than 1, it will combine the information across batch elements. This branch fix this.

## Status
**READY**

## Description
cf above.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


## Todos
- [ ] Tests
- [ ] Documentation


## Impacted Areas in Application
List general components of the application that this PR will affect:
*
