### PR TITLE
457 subpixel convolution upgrade

### DIFF
--- a/niftynet/layer/subpixel.py
+++ b/niftynet/layer/subpixel.py
@@ -3,110 +3,186 @@ from __future__ import absolute_import, print_function
 
 import tensorflow as tf
 
-from niftynet.layer import layer_util
 from niftynet.layer.base_layer import TrainableLayer
 from niftynet.layer.convolution import ConvolutionalLayer
+from niftynet.layer.downsample import DownSampleLayer
 
 
 class SubPixelLayer(TrainableLayer):
     """
-    Implementation of Shi et al.'s sub-pixel CNN single-image
-    upsampling method.
+    Implementation of:
 
-    Based on Shi et al.: "Real-Time Single Image and Video
-    Super-Resolution Using an Efficient Sub-Pixel Convolutional Neural
-    Network"
+    SubPixel Convolution initialised with ICNR initialisation
+    and followed by an AveragePooling
+
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Shi, W., Caballero, J., Huszár, F., Totz, J., Aitken, A.P.,
+    Bishop, R., Rueckert, D. and Wang, Z., 2016.
+
+    Real-time single image and video super-resolution using an
+    efficient sub-pixel convolutional neural network.
+
+    In Proceedings of the IEEE conference on computer vision
+    and pattern recognition (pp. 1874-1883).
+
+    https://www.cv-foundation.org/openaccess/content_cvpr_2016/
+    papers/Shi_Real-Time_Single_Image_CVPR_2016_paper.pdf
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Aitken, A., Ledig, C., Theis, L., Caballero, J., Wang, Z.
+    and Shi, W., 2017.
+
+    Checkerboard artifact free sub-pixel convolution: A note on
+    sub-pixel convolution, resize convolution and convolution
+    resize.
+
+    arXiv preprint arXiv:1707.02937.
+
+    https://arxiv.org/pdf/1707.02937.pdf
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Sugawara, Y., Shiota, S. and Kiya, H., 2018, October.
+
+    Super-resolution using convolutional neural networks without
+    any checkerboard artifacts.
+
+    In 2018 25th IEEE International Conference on Image Processing
+    (ICIP) (pp. 66-70). IEEE.
+
+    https://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=8451141
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     """
 
-    def __init__(self,
-                 upsample_factor=3,
-                 layer_configurations=((5, 64),
-                                       (3, 32),
-                                       (3, -1)),
-                 acti_func='tanh',
-                 feature_normalization=None,
-                 group_size=-1,
-                 with_bias=True,
-                 padding='REFLECT',
-                 w_initializer=None,
-                 w_regularizer=None,
-                 b_initializer=None,
-                 b_regularizer=None,
-                 name='subpixel_cnn'):
+    def __init__(
+        self,
+        upsample_factor=2,
+        no_img_channels=1,
+        kernel_size=3,
+        acti_func="tanh",
+        feature_normalization=None,
+        group_size=-1,
+        with_bias=True,
+        padding="REFLECT",
+        use_icnr=True,
+        use_avg=True,
+        w_initializer=None,
+        w_regularizer=None,
+        b_initializer=None,
+        b_regularizer=None,
+        name="subpixel_cnn",
+    ):
         """
         :param upsample_factor: zoom-factor/image magnification factor
-        :param layer_configurations: N pairs consisting of a kernel size and
-        a feature-map size, where N is the number of layers in the net. The last
-        layer must have a feature-map size of -1.
-        :param padding: padding applied in convolutional layers
-        :param with_bias: incorporate bias parameters in convolutional layers
-        :param feature_normalization: the type of feature normalization (e.g.
-                batch, instance or group norm. Default None.
-        :param group_size: size of the groups if groupnorm is chosen.
+        :param no_img_channels: the desired ammount of channels for the
+        upsampled image
+        :param kernel_size: the size of the convolutional kernels
         :param acti_func: activation function applied to first N - 1 layers
+        :param feature_normalization: the type of feature normalization (e.g.
+        batch, instance or group norm. Default None.
+        :param group_size: size of the groups if groupnorm is chosen.
+        :param with_bias: incorporate bias parameters in convolutional layers
+        :param padding: padding applied in convolutional layers
+        :param use_icnr: whether to use Aitken et al. initialization
+        :param use_avg: whether to use Sugawara et al. post-processing
         """
 
         super(SubPixelLayer, self).__init__(name=name)
 
-        if layer_configurations[-1][1] != -1:
-            raise ValueError('The size of the last feature map must be -1')
         if upsample_factor <= 0:
-            raise ValueError('The upsampling factor must be strictly positive.')
+            raise ValueError("The upsampling factor must be strictly positive.")
 
         self.upsample_factor = upsample_factor
-        self.layer_configurations = layer_configurations
+        self.kernel_size = kernel_size
         self.acti_func = acti_func
+        self.use_avg = use_avg
+        self.no_img_channels = no_img_channels
 
-        self.conv_layer_params = {'with_bias': with_bias,
-                                  'feature_normalization': feature_normalization,
-                                  'group_size': group_size,
-                                  'padding': padding,
-                                  'w_initializer': w_initializer,
-                                  'b_initializer': b_initializer,
-                                  'w_regularizer': w_regularizer,
-                                  'b_regularizer': b_regularizer}
+        self.conv_layer_params = {
+            "with_bias": with_bias,
+            "feature_normalization": feature_normalization,
+            "group_size": group_size,
+            "padding": padding,
+            "w_initializer": w_initializer
+            if not use_icnr
+            else ICNR(
+                initializer=tf.keras.initializers.get(w_initializer),
+                upsample_factor=upsample_factor,
+            ),
+            "b_initializer": b_initializer,
+            "w_regularizer": w_regularizer,
+            "b_regularizer": b_regularizer,
+        }
 
-    def layer_op(self, lr_images, is_training=True, keep_prob=1.0):
-        input_shape = lr_images.shape.as_list()
-        batch_size = input_shape[0]
-        input_shape = input_shape[1:]
-        n_of_dims = len(input_shape) - 1
+    def layer_op(self, lr_image, is_training=True, keep_prob=1.0):
+        input_shape = lr_image.get_shape().as_list()
+        batch_size = input_shape.pop(0)
 
         if batch_size is None:
-            raise ValueError('The batch size must be known and fixed.')
+            raise ValueError("The batch size must be known and fixed.")
         if any(i is None or i <= 0 for i in input_shape):
-            raise ValueError('The image shape must be known in advance.')
+            raise ValueError("The image shape must be known in advance.")
 
-        n_of_channels = input_shape[-1]
-
-        features = lr_images
-        for i, (ksize, n_of_features) in enumerate(self.layer_configurations):
-            name = 'fmap_{}'.format(i)
-
-            if n_of_features > 0:
-                conv = ConvolutionalLayer(n_of_features,
-                                          kernel_size=ksize,
-                                          acti_func=self.acti_func,
-                                          name=name,
-                                          **self.conv_layer_params)
-            else:
-                n_of_features = n_of_channels * self.upsample_factor ** n_of_dims
-                conv = ConvolutionalLayer(n_of_features,
-                                          kernel_size=ksize,
-                                          acti_func=None,
-                                          name=name,
-                                          **self.conv_layer_params)
-
-            features = conv(features, is_training=is_training,
-                            keep_prob=keep_prob)
+        # Making sure there are enough features channels for the
+        # periodic shuffling
+        features = ConvolutionalLayer(
+            n_output_chns=(
+                self.no_img_channels *
+                self.upsample_factor ** (len(input_shape) - 1)
+            ),
+            kernel_size=self.kernel_size,
+            acti_func=None,
+            name="subpixel_conv",
+            **self.conv_layer_params
+        )(input_tensor=lr_image, is_training=is_training, keep_prob=keep_prob)
 
         # Setting the number of output features to the known value
         # obtained from the input shape results in a ValueError as
         # of TF 1.12
-        output_shape = ([batch_size] +
-                        [self.upsample_factor * i for i in input_shape[:-1]] + 
-                        [None])
+        sr_image = tf.contrib.periodic_resample.periodic_resample(
+            values=features,
+            shape=(
+                [batch_size]
+                + [self.upsample_factor * i for i in input_shape[:-1]]
+                + [None]
+            ),
+            name="periodic_shuffle",
+        )
 
-        return tf.contrib.periodic_resample.periodic_resample(features,
-                                                              output_shape,
-                                                              name='shuffle')
+        # Averaging out the values without downsampling to counteract
+        # the periodicity of periodic shuffling as per Sugawara et al.
+        if self.use_avg:
+            sr_image = DownSampleLayer(
+                func="AVG",
+                kernel_size=self.upsample_factor,
+                stride=1,
+                padding="SAME",
+                name="averaging",
+            )(input_tensor=sr_image)
+
+        return sr_image
+
+
+class ICNR:
+    def __init__(self, initializer, upsample_factor=1):
+        """
+        :param initializer:  initializer used for sub kernels (orthogonal, glorot uniform, etc.)
+        :param upsample_factor: upsample factor of sub pixel convolution
+        """
+        self.upsample_factor = upsample_factor
+        self.initializer = initializer
+
+    def __call__(self, shape, dtype, partition_info=None):
+        shape = list(shape)
+        if self.upsample_factor == 1:
+            return self.initializer(shape)
+
+        # Initializing W0 (enough kernels for one output channel)
+        new_shape = shape[:-1] + [shape[-1] // (self.upsample_factor ** 2)]
+        x = self.initializer(new_shape, dtype, partition_info)
+
+        # Repeat the elements along the output dimension
+        x = tf.keras.backend.repeat_elements(
+            x=x,
+            rep=self.upsample_factor ** 2,
+            axis=-1
+        )
+
+        return x

--- a/niftynet/layer/subpixel.py
+++ b/niftynet/layer/subpixel.py
@@ -182,13 +182,13 @@ class ICNR:
             return self.initializer(shape)
 
         # Initializing W0 (enough kernels for one output channel)
-        new_shape = shape[:-1] + [shape[-1] // (self.upsample_factor ** 2)]
+        new_shape = shape[:-1] + [shape[-1] // (self.upsample_factor ** (len(shape)-2))]
         x = self.initializer(new_shape, dtype, partition_info)
 
         # Repeat the elements along the output dimension
         x = tf.keras.backend.repeat_elements(
             x=x,
-            rep=self.upsample_factor ** 2,
+            rep=self.upsample_factor ** len(shape)-2,
             axis=-1
         )
 

--- a/niftynet/layer/subpixel.py
+++ b/niftynet/layer/subpixel.py
@@ -15,6 +15,11 @@ class SubPixelLayer(TrainableLayer):
     SubPixel Convolution initialised with ICNR initialisation
     and followed by an AveragePooling
 
+    Limitations:
+
+    If ICNR initialization is used then the upsample factor
+    MUST be an integer
+
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     Shi, W., Caballero, J., Huszár, F., Totz, J., Aitken, A.P.,
     Bishop, R., Rueckert, D. and Wang, Z., 2016.
@@ -88,6 +93,8 @@ class SubPixelLayer(TrainableLayer):
 
         if upsample_factor <= 0:
             raise ValueError("The upsampling factor must be strictly positive.")
+        if int(upsample_factor)!=float(upsample_factor) and use_icnr:
+            raise ValueError("If ICNR initialization is used the sample factor must be an integer")
 
         self.upsample_factor = upsample_factor
         self.kernel_size = kernel_size

--- a/tests/subpixel_test.py
+++ b/tests/subpixel_test.py
@@ -7,84 +7,73 @@ import tensorflow as tf
 from niftynet.layer.subpixel import SubPixelLayer
 from tests.niftynet_testcase import NiftyNetTestCase
 
+
 class SubPixelTest(NiftyNetTestCase):
     """
     Test for niftynet.layer.subpixel.SubPixelLayer.
     Mostly adapted from convolution_test.py
     """
 
-    def get_3d_input(self):
-        input_shape = (2, 16, 16, 16, 8)
-        x_3d = tf.ones(input_shape)
+    def get_3d_input(self, shape=(2, 16, 16, 16, 8)):
+        x_3d = tf.ones(shape)
         return x_3d
 
-    def get_2d_input(self):
-        input_shape = (2, 16, 16, 8)
-        x_2d = tf.ones(input_shape)
+    def get_2d_input(self, shape=(2, 16, 16, 4)):
+        x_2d = tf.ones(shape)
         return x_2d
-
-    def _test_subpixel_output_shape(self,
-                                    input_data,
-                                    param_dict,
-                                    output_shape):
-        layer = SubPixelLayer(**param_dict)
-        output_data = layer(input_data)
-        print(layer)
-        with self.cached_session() as sess:
-            sess.run(tf.global_variables_initializer())
-            output_value = sess.run(output_data)
-            self.assertAllClose(output_shape, output_value.shape)
 
     def _make_output_shape(self, data, upsampling):
         data_shape = data.shape.as_list()
         output_shape = [data_shape[0]]
         output_shape += [upsampling * d for d in data_shape[1:-1]]
-        output_shape += [data_shape[-1]]
-
+        output_shape += [data_shape[-1] // (upsampling ** (len(data_shape) - 2))]
         return output_shape
+
+    def _test_subpixel_output_shape(self, input_data, param_dict, output_shape):
+        layer = SubPixelLayer(**param_dict)
+        output_data = layer(lr_image=input_data, is_training=True, keep_prob=1.0)
+        with self.cached_session() as sess:
+            sess.run(tf.global_variables_initializer())
+            output_value = sess.run(output_data)
+            self.assertAllClose(output_shape, output_value.shape)
 
     def test_3d_default(self):
         data = self.get_3d_input()
 
-        output_shape = self._make_output_shape(data, 3)
+        output_shape = self._make_output_shape(data, 2)
 
-        self._test_subpixel_output_shape(data,
-                                         {},
-                                         output_shape)
+        self._test_subpixel_output_shape(data, {}, output_shape)
+
+    def test_2d_default(self):
+        data = self.get_2d_input()
+
+        output_shape = self._make_output_shape(data, 2)
+
+        self._test_subpixel_output_shape(data, {}, output_shape)
 
     def test_3d_bespoke(self):
-        data = self.get_3d_input()
         upsampling = 4
+        data = self.get_3d_input(
+            shape=(2, 16, 16, 16, upsampling**3)
+        )
 
         output_shape = self._make_output_shape(data, upsampling)
 
-        params = {'upsample_factor': upsampling,
-                  'layer_configurations': ((6, 32),
-                                           (3, 32),
-                                           (2, 16),
-                                           (4, -1)),
-                  'padding': 'SAME'}
+        params = {"upsample_factor": upsampling, "kernel_size": 4, "padding": "SAME"}
 
-        self._test_subpixel_output_shape(data,
-                                         params,
-                                         output_shape)
+        self._test_subpixel_output_shape(data, params, output_shape)
 
     def test_2d_bespoke(self):
-        data = self.get_2d_input()
         upsampling = 6
+        data = self.get_2d_input(
+            shape=(2, 16, 16, upsampling ** 2)
+        )
 
         output_shape = self._make_output_shape(data, upsampling)
 
-        params = {'upsample_factor': upsampling,
-                  'layer_configurations': ((6, 32),
-                                           (3, 32),
-                                           (2, 16),
-                                           (4, -1)),
-                  'padding': 'SAME'}
+        params = {"upsample_factor": upsampling, "kernel_size": 4, "padding": "SAME"}
 
-        self._test_subpixel_output_shape(data,
-                                         params,
-                                         output_shape)
+        self._test_subpixel_output_shape(data, params, output_shape)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Status
READY

## Description
Restructured SubPixel convolution to fall in line with Figure 1 from [1].
Added ICNR initialization [2], but with the partial limitation that if it is used the upsampling factor must be an integer.
Added the post-processing from [3].
[1] [Real-Time Single Image and Video Super-Resolution Using an Efficient Sub-Pixel Convolutional Neural Network](https://arxiv.org/pdf/1609.05158.pdf)
[2] [Checkerboard artifact free sub-pixel convolution](https://arxiv.org/pdf/1707.02937.pdf)
[3] [Checkerboard artifacts free convolutional neural networks](https://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=8451141&tag=1) 

## Types of changes
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.

## Todos
- [x] Documentation

## Impacted Areas in Application
List general components of the application that this PR will affect:
* niftynet/layers/subpixel.py
