### PR TITLE
Fixed bug when logging discriminator loss for tensorboard in GAN application

### DIFF
--- a/niftynet/application/gan_application.py
+++ b/niftynet/application/gan_application.py
@@ -215,10 +215,10 @@ class GANApplication(BaseApplication):
                 collection=CONSOLE)
             # variables to display in tensorboard
             outputs_collector.add_to_collection(
-                var=lossG, name='lossG', average_over_devices=False,
+                var=lossD, name='lossD', average_over_devices=True,
                 collection=TF_SUMMARIES)
             outputs_collector.add_to_collection(
-                var=lossG, name='lossD', average_over_devices=True,
+                var=lossG, name='lossG', average_over_devices=False,
                 collection=TF_SUMMARIES)
 
             with tf.name_scope('Optimiser'):


### PR DESCRIPTION
## Status
**READY**

## Description
There was a bug when logging the Discrimiantor loss in the GAN application: the Generator loss would be logged instead. This fixes that.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


## Todos
- [ ] Tests
- [ ] Documentation

I ran the tests before and after the change, and the same error came up:
```
.2020-01-16 13:44:12.961729: F ./tensorflow/core/util/mkl_util.h:636] Check failed: dims == sizes.size() (5 vs. 4)
```

I'm very confident that this minor change doesn't break anything and I was able to check that it works in my own code.

## Impacted Areas in Application
List general components of the application that this PR will affect:
* `niftynet.application.GANApplication`
