### PR TITLE
Added GAN parameter for logging generated images to Tensorboard

### DIFF
--- a/niftynet/engine/application_variables.py
+++ b/niftynet/engine/application_variables.py
@@ -9,7 +9,8 @@ import tensorflow as tf
 from tensorflow.contrib.framework import list_variables
 
 from niftynet.io.misc_io import \
-    image3_axial, image3_coronal, image3_sagittal, resolve_checkpoint
+    image3_axial, image3_coronal, image3_sagittal, \
+    image3_axial_n, image3_coronal_n, image3_sagittal_n, resolve_checkpoint
 from niftynet.utilities import util_common as util
 from niftynet.utilities.restore_initializer import restore_initializer
 
@@ -22,8 +23,10 @@ SUPPORTED_SUMMARY = {'scalar': tf.summary.scalar,
                      'image': tf.summary.image,
                      'image3_sagittal': image3_sagittal,
                      'image3_coronal': image3_coronal,
-                     'image3_axial': image3_axial}
-
+                     'image3_axial': image3_axial,
+                     'image3_sagittal_n': image3_sagittal_n,
+                     'image3_coronal_n': image3_coronal_n,
+                     'image3_axial_n': image3_axial_n}
 
 class GradientsCollector(object):
     """

--- a/niftynet/io/misc_io.py
+++ b/niftynet/io/misc_io.py
@@ -840,6 +840,55 @@ def image3_axial(name,
     return image3(name, tensor, max_outputs, collections, [3], [1, 2])
 
 
+def image3_sagittal_n(name,
+                    tensor,
+                    collections=(tf.GraphKeys.SUMMARIES, )):
+    """
+    Create 2D image summary in the sagittal view. An image will be generated for
+    every element in axis 0 of the tensor.
+
+    :param name:
+    :param tensor:
+    :param max_outputs:
+    :param collections:
+    :return:
+    """
+    return image3(name, tensor, tensor.shape.as_list()[0], collections, [1], [2, 3])
+
+
+def image3_coronal_n(name,
+                   tensor,
+                   collections=(tf.GraphKeys.SUMMARIES, )):
+    """
+    Create 2D image summary in the coronal view. An image will be generated for
+    every element in axis 0 of the tensor.
+
+    :param name:
+    :param tensor:
+    :param max_outputs:
+    :param collections:
+    :return:
+    """
+    return image3(name, tensor, tensor.shape.as_list()[0], collections, [2], [1, 3])
+
+
+def image3_axial_n(name,
+                 tensor,
+                 max_outputs=3,
+                 collections=(tf.GraphKeys.SUMMARIES, )):
+    """
+    Create 2D image summary in the axial view. An image will be generated for
+    every element in axis 0 of the tensor.
+
+    :param name:
+    :param tensor:
+    :param max_outputs:
+    :param collections:
+    :return:
+    """
+    return image3(name, tensor, tensor.shape.as_list()[0], collections, [3], [1, 2])
+
+
 def set_logger(file_name=None):
     """
     Writing logs to a file if file_name,

--- a/niftynet/utilities/user_parameters_custom.py
+++ b/niftynet/utilities/user_parameters_custom.py
@@ -211,6 +211,12 @@ def __add_gan_args(parser):
         type=int,
         default=10)
 
+    parser.add_argument(
+        "--tensorboard_n_fake_images",
+        help="the number of fake images to log to Tensorboard in every update",
+        type=int,
+        default=0)
+
     from niftynet.application.gan_application import SUPPORTED_INPUT
     parser = add_input_name_args(parser, SUPPORTED_INPUT)
     return parser


### PR DESCRIPTION
## Status
**WORK IN PROGRESS**

## Description
The goal of this change is to add a new parameter to the GAN application in order to log 2D views of 3D images in Tensorboard. It adds a `tensorboard_n_fake_images` argument to the GAN section, with a default of zero. This is the number of images that will be logged to Tensorboard at each training logging step (`tensorbard_every_n`), 3 views (sagittal, coronal and axial) for each image.

This was already implemented in segmentation tasks, but not GAN. Some of the implementation decissions previously taken have affected the way this was implemented, so as to not break previous work: I've only added, not modified.

In particular the `max_out` parameter in `niftynet.io.misc_io.image3`,  and the `max_outputs` parameter in `niftynet.io.misc_io.image3_sagittal`, `niftynet.io.misc_io.image3_axial` and `niftynet.io.misc_io.image3_coronal` has made it a little difficult to implement. This has introduced some code repetition: as far as I know, it's not possible to pass this argument to `OutputsCollector.add_to_collection`, so new functions without these arguments needed to be created.

In my opinion, this parameter could be removed and just take a slice of the tensor to log before passing it in, like I've done in `GANApplication`, but I don't have the necessary knowledge about previous code to assess this well.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


## Todos
- [ ] Tests
- [x] Documentation


## Impacted Areas in Application
List general components of the application that this PR will affect:
* `niftynet.application.gan_application.GANApplication`
