### PR TITLE
Segmentation configuration file fix

### DIFF
--- a/config/default_multimodal_segmentation_eval.ini
+++ b/config/default_multimodal_segmentation_eval.ini
@@ -68,7 +68,6 @@ spatial_window_size = (64, 64, 64)
 [EVALUATION]
 save_csv_dir = ./NiftyNetTestEval
 evaluations = dice,jaccard,false_positive_rate,positive_predictive_values,n_pos_ref,n_pos_seg
-evaluation_units = foreground
 
 
 ############################ custom configuration sections
@@ -82,3 +81,4 @@ weight = T1
 output_prob = False
 num_classes = 5
 label_normalisation = False
+evaluation_units = foreground

--- a/demos/unet_histology/config.ini
+++ b/demos/unet_histology/config.ini
@@ -51,7 +51,6 @@ dataset_to_infer = inference
 [EVALUATION]
 save_csv_dir = ./eval.csv
 evaluations = dice
-evaluation_units = label
 
 ############################ Application Configuration
 [SEGMENTATION]
@@ -61,3 +60,4 @@ sampler = label
 label_normalisation = False
 output_prob = False
 num_classes = 2
+evaluation_units = label


### PR DESCRIPTION
## Status
**READY**

## Description
The `--evaluation_units` parameter was located under [EVALUATION], instead of [SEGMENTATION]  in two of the provided config files. So when using these files, the parameter is not read out, and the default value foreground is used instead.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] My code follows the code style of this project.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


## Todos
- [ ] Tests
- [ ] Documentation


## Impacted Areas in Application
List general components of the application that this PR will affect:
* Config files
